### PR TITLE
Adding Forms to AssessmentQueryRepository

### DIFF
--- a/client/src/main/java/tds/assessment/Form.java
+++ b/client/src/main/java/tds/assessment/Form.java
@@ -1,0 +1,123 @@
+package tds.assessment;
+
+/**
+ * A model representing a form for an {@link tds.assessment.Assessment}
+ */
+public class Form {
+    private String key;
+    private String id;
+    private String language;
+    private String cohort;
+    private String segmentKey;
+    private Long loadVersion;
+    private Long updateVersion;
+
+    private Form(Builder builder) {
+        key = builder.key;
+        id = builder.id;
+        language = builder.language;
+        cohort = builder.cohort;
+        segmentKey = builder.segmentKey;
+        loadVersion = builder.loadVersion;
+        updateVersion = builder.updateVersion;
+    }
+
+    public static class Builder {
+        private String key;
+        private String id;
+        private String language;
+        private String cohort;
+        private String segmentKey;
+        private Long loadVersion;
+        private Long updateVersion;
+
+
+        public Builder (String key) {
+            this.key = key;
+        }
+
+        public Builder withId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withLanguage(String language) {
+            this.language = language;
+            return this;
+        }
+
+        public Builder withCohort(String cohort) {
+            this.cohort = cohort;
+            return this;
+        }
+
+        public Builder withSegmentKey(String segmentKey) {
+            this.segmentKey = segmentKey;
+            return this;
+        }
+
+        public Builder withLoadVersion(Long loadVersion) {
+            this.loadVersion = loadVersion;
+            return this;
+        }
+
+        public Builder withUpdateVersion(Long updateVersion) {
+            this.updateVersion = updateVersion;
+            return this;
+        }
+
+        public Form build() {
+            return new Form(this);
+        }
+    }
+
+    /**
+     * @return the language for the form
+     */
+    public String getLanguage() {
+        return language;
+    }
+
+    /**
+     * @return the key of the form (ex: 187-582)
+     */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * @return the id of the form
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * @return the cohort of the form
+     */
+    public String getCohort() {
+        return cohort;
+    }
+
+    /**
+     * @return the key of the segment this form is a child of
+     */
+    public String getSegmentKey() {
+        return segmentKey;
+    }
+
+    /**
+     * @return the originally loaded version of this form
+     */
+    public Long getLoadVersion() {
+        return loadVersion;
+    }
+
+    /**
+     * @return an optional "update" version of the form
+     */
+    public Long getUpdateVersion() {
+        return updateVersion;
+    }
+
+}

--- a/client/src/main/java/tds/assessment/Segment.java
+++ b/client/src/main/java/tds/assessment/Segment.java
@@ -12,7 +12,11 @@ public class Segment {
     private float startAbility;
     private String subject;
     private String assessmentKey;
+    private int position;
+    private int minItems;
+    private int maxItems;
     private List<Property> languages;
+    private List<Form> forms;
 
     private Segment(Builder builder) {
         key = builder.key;
@@ -21,7 +25,11 @@ public class Segment {
         startAbility = builder.startAbility;
         subject = builder.subject;
         assessmentKey = builder.assessmentKey;
+        position = builder.position;
+        minItems = builder.minItems;
+        maxItems = builder.maxItems;
         languages = builder.languages;
+        forms = builder.forms;
     }
 
     /**
@@ -73,6 +81,34 @@ public class Segment {
         return languages;
     }
 
+    /**
+     * @return the position of the segment in the {@link Assessment}
+     */
+    public int getPosition() {
+        return position;
+    }
+
+    /**
+     * @return the minimum number of items in the {@link Segment}
+     */
+    public int getMinItems() {
+        return minItems;
+    }
+
+    /**
+     * @return the minimum number of items in the {@link Segment}
+     */
+    public int getMaxItems() {
+        return maxItems;
+    }
+
+    /**
+     * @return return the forms that are a part of this assessment's {@link tds.assessment.Segment}
+     */
+    public List<Form> getForms() {
+        return forms;
+    }
+
     public static class Builder {
         private String key;
         private String segmentId;
@@ -80,7 +116,11 @@ public class Segment {
         private float startAbility;
         private String subject;
         private String assessmentKey;
+        private int position;
+        private int minItems;
+        private int maxItems;
         private List<Property> languages;
+        private List<Form> forms;
 
         public Builder(String key) {
             this.key = key;
@@ -113,6 +153,26 @@ public class Segment {
 
         public Builder withLanguages(List<Property> languages) {
             this.languages = languages;
+            return this;
+        }
+
+        public Builder withPosition(int position) {
+            this.position = position;
+            return this;
+        }
+
+        public Builder withMinItems(int minItems) {
+            this.minItems = minItems;
+            return this;
+        }
+
+        public Builder withMaxItems(int maxItems) {
+            this.maxItems = maxItems;
+            return this;
+        }
+
+        public Builder withForms(List<Form> forms) {
+            this.forms = forms;
             return this;
         }
 

--- a/service/src/main/java/tds/assessment/repositories/impl/AssessmentMapper.java
+++ b/service/src/main/java/tds/assessment/repositories/impl/AssessmentMapper.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import tds.assessment.Assessment;
+import tds.assessment.Form;
 import tds.assessment.Property;
 import tds.assessment.Segment;
 
@@ -22,7 +23,7 @@ class AssessmentMapper {
      * @param rows
      * @return
      */
-    Optional<Assessment> mapResults(List<Map<String, Object>> rows) {
+    Optional<Assessment> mapResults(List<Map<String, Object>> rows, List<Form> forms) {
         Map<String, SegmentInformationHolder> segments = new LinkedHashMap<>();
         Map<String, Object> assessmentRow = null;
         for (Map<String, Object> row : rows) {
@@ -36,14 +37,20 @@ class AssessmentMapper {
                 }
 
                 SegmentInformationHolder holder = segments.get(key);
+                String segmentKey = (String) row.get("assessmentSegmentKey");
 
                 //If holder is null this is the first record for this segment
-                Segment.Builder segment = new Segment.Builder((String) row.get("assessmentSegmentKey"))
+                Segment.Builder segment = new Segment.Builder(segmentKey)
                     .withSegmentId((String) row.get("assessmentSegmentId"))
                     .withAssessmentKey((String) row.get("assessmentKey"))
                     .withSelectionAlgorithm((String) row.get("selectionalgorithm"))
+                    .withMinItems((int) row.get("minItems"))
+                    .withMaxItems((int) row.get("maxItems"))
                     .withStartAbility((float) row.get("startAbility"))
-                    .withSubject((String) row.get("subject"));
+                    .withPosition((Integer) row.get("segmentPosition"))
+                    .withSubject((String) row.get("subject"))
+                    .withForms(forms.stream()
+                        .filter(form -> form.getSegmentKey().equals(segmentKey)).collect(Collectors.toList()));
 
                 holder.setSegment(segment);
 
@@ -73,7 +80,11 @@ class AssessmentMapper {
                 .withSelectionAlgorithm((String) assessmentRow.get("selectionalgorithm"))
                 .withStartAbility((float) assessmentRow.get("startAbility"))
                 .withAssessmentKey((String) assessmentRow.get("assessmentSegmentKey"))
-                .withSubject((String) assessmentRow.get("subject"));
+                .withPosition(1)
+                .withMinItems((int) assessmentRow.get("minItems"))
+                .withMaxItems((int) assessmentRow.get("maxItems"))
+                .withSubject((String) assessmentRow.get("subject"))
+                .withForms(forms);
 
             if (assessmentRow.containsKey("propname")) {
                 Property language = new Property(

--- a/service/src/main/java/tds/assessment/repositories/impl/AssessmentQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/assessment/repositories/impl/AssessmentQueryRepositoryImpl.java
@@ -77,7 +77,7 @@ class AssessmentQueryRepositoryImpl implements AssessmentQueryRepository {
                         "    forms.updateconfig AS updateVersion, \n" +
                         "    forms.cohort \n" +
                         "FROM itembank.tblsetofadminsubjects segments \n" +
-                        "LEFT JOIN itembank.testform forms ON segments._key = forms._fk_adminsubject \n" +
+                        "JOIN itembank.testform forms ON segments._key = forms._fk_adminsubject \n" +
                         "WHERE segments.virtualtest = :key OR segments._key = :key";
 
 

--- a/service/src/test/java/tds/assessment/repositories/AssessmentQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/assessment/repositories/AssessmentQueryRepositoryImplIntegrationTests.java
@@ -10,9 +10,12 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.sql.DataSource;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import tds.assessment.Assessment;
+import tds.assessment.Form;
 import tds.assessment.Property;
 import tds.assessment.Segment;
 
@@ -47,11 +50,11 @@ public class AssessmentQueryRepositoryImplIntegrationTests {
                 "0,'bp1',NULL,NULL,'summative');";
         // Segment 1
         String tblSetOfAdminSubjectsInsertSQL2a = "INSERT INTO itembank.tblsetofadminsubjects VALUES ('(SBAC_PT)SBAC-SEG1-MATH-8-Spring-2013-2015','SBAC_PT', 'SBAC_PT-ELA','SBAC-SEG1-MATH-8'," +
-                "0,1,4,4,1,1,NULL,NULL,0,0,NULL,'fixedform',NULL,5,1,20,1,5,'(SBAC_PT)SBAC-Mathematics-8-Spring-2013-2015',NULL,0,1,8185,8185,5,0,'SBAC_PT',NULL,'ABILITY',NULL,1,NULL,1,1,NULL,NULL,0,0,0,0," +
+                "0,1,4,4,1,1,NULL,NULL,0,0,NULL,'fixedform',NULL,5,1,20,1,5,'(SBAC_PT)SBAC-Mathematics-8-Spring-2013-2015',1,0,1,8185,8185,5,0,'SBAC_PT',NULL,'ABILITY',NULL,1,NULL,1,1,NULL,NULL,0,0,0,0," +
                 "0,'bp1',NULL,NULL,'summative');";
         // Segment2
         String tblSetOfAdminSubjectsInsertSQL2b = "INSERT INTO itembank.tblsetofadminsubjects VALUES ('(SBAC_PT)SBAC-SEG2-MATH-8-Spring-2013-2015','SBAC_PT', 'SBAC_PT-ELA','SBAC-SEG2-MATH-8'," +
-                "0,1,4,4,1,1,NULL,NULL,0,0,NULL,'fixedform',NULL,5,1,20,1,5,'(SBAC_PT)SBAC-Mathematics-8-Spring-2013-2015',NULL,0,1,8185,8185,5,0,'SBAC_PT',NULL,'ABILITY',NULL,1,NULL,1,1,NULL,NULL,0,0,0,0," +
+                "0,1,4,4,1,1,NULL,NULL,0,0,NULL,'fixedform',NULL,5,1,20,1,5,'(SBAC_PT)SBAC-Mathematics-8-Spring-2013-2015',2,0,1,8185,8185,5,0,'SBAC_PT',NULL,'ABILITY',NULL,1,NULL,1,1,NULL,NULL,0,0,0,0," +
                 "0,'bp1',NULL,NULL,'summative');";
 
         String tblitemPropsInsertSQL = "insert into itembank.tblitemprops (_fk_item, propname, propvalue, propdescription, _fk_adminsubject, isactive) \n" +
@@ -61,6 +64,21 @@ public class AssessmentQueryRepositoryImplIntegrationTests {
             "('item-23', 'Language', 'ENU', 'Supported Language', '(SBAC_PT)SBAC-SEG2-MATH-8-Spring-2013-2015', 0),\n" +
             "('item-2', 'Language', 'Braille-ENU', 'Supported Language', '(SBAC_PT)SBAC-SEG2-MATH-8-Spring-2013-2015', 1);";
 
+        String testformInsertSQL =
+                "INSERT INTO itembank.testform\n" +
+                        "   (_fk_adminsubject, _efk_itsbank, _efk_itskey, formid, language, _key, itsid, iteration, loadconfig, updateconfig, cohort)\n" +
+                        "VALUES \n" +
+                        "   ('(SBAC_PT)SBAC-SEG1-MATH-8-Spring-2013-2015', 528, 528, 'PracTest::MG8::S1::SP14', 'ENU', '187-528', NULL, 0, 8233, 8234, 'Default'),\n" +
+                        "   ('(SBAC_PT)SBAC-SEG1-MATH-8-Spring-2013-2015', 529, 529, 'PracTest::MG8::S1::SP14::Braille', 'ENU-Braille', '187-529', NULL, 0, 8233, 8234, 'Default'),\n" +
+                        "   ('(SBAC_PT)SBAC-SEG1-MATH-8-Spring-2013-2015', 530, 530, 'PracTest::MG8::S1::SP14::ESN', 'ESN', '187-530', NULL, 0, 8233, 8234, 'Default'),\n" +
+                        "   ('(SBAC_PT)SBAC-SEG2-MATH-8-Spring-2013-2015', 531, 531, 'PracTest::MG8::S2::SP14', 'ENU', '187-531', NULL, 0, 8233, NULL, 'Default'),\n" +
+                        "   ('(SBAC_PT)SBAC-SEG2-MATH-8-Spring-2013-2015', 532, 532, 'PracTest::MG8::S2::SP14::Braille', 'ENU-Braille', '187-532', NULL, 0, 8233, NULL, 'Default'),\n" +
+                        "   ('(SBAC_PT)SBAC-SEG2-MATH-8-Spring-2013-2015', 533, 533, 'PracTest::MG8::S2::SP14::ESN', 'ESN', '187-533', NULL, 0, 8233, NULL, 'Default'), \n " +
+                        "   ('(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016',510, 510,'PracTest::MG4::S1::SP14','ENU','187-510',NULL,0,8233,NULL,'Default'), \n" +
+                        "   ('(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016',511, 511,'PracTest::MG4::S1::SP14::Braille','ENU-Braille','187-511',NULL,0,8233,NULL,'Default'),\n" +
+                        "   ('(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016',512, 512,'PracTest::MG4::S1::SP14::ESN','ESN','187-512',NULL,0,8233,NULL,'Default')\n";
+
+
         jdbcTemplate.update(tblClientInsertSQL);
         jdbcTemplate.update(tblSubjectInsertSQL);
         jdbcTemplate.update(tblSetOfAdminSubjectsInsertSQL1);
@@ -68,12 +86,13 @@ public class AssessmentQueryRepositoryImplIntegrationTests {
         jdbcTemplate.update(tblSetOfAdminSubjectsInsertSQL2a);
         jdbcTemplate.update(tblSetOfAdminSubjectsInsertSQL2b);
         jdbcTemplate.update(tblitemPropsInsertSQL);
+        jdbcTemplate.update(testformInsertSQL);
     }
 
     @Test
     public void shouldNotFindAssessmentByKey() {
-        Optional<Assessment> maybeSetOfAdminObject = repository.findAssessmentByKey("BOGUS");
-        assertThat(maybeSetOfAdminObject).isNotPresent();
+        Optional<Assessment> maybeAssessment = repository.findAssessmentByKey("BOGUS");
+        assertThat(maybeAssessment).isNotPresent();
     }
 
     @Test
@@ -92,9 +111,52 @@ public class AssessmentQueryRepositoryImplIntegrationTests {
         assertThat(seg.getStartAbility()).isEqualTo(maybeAssessment.get().getStartAbility());
         assertThat(seg.getAssessmentKey()).isEqualTo(maybeAssessment.get().getKey());
         assertThat(seg.getSubject()).isEqualTo(maybeAssessment.get().getSubject());
+        assertThat(seg.getPosition()).isEqualTo(1);
+        assertThat(seg.getMinItems()).isEqualTo(4);
+        assertThat(seg.getMaxItems()).isEqualTo(4);
         assertThat(seg.getLanguages()).hasSize(1);
         assertThat(seg.getLanguages()).containsOnly(new Property("Language", "ENU"));
         assertThat(seg.getSelectionAlgorithm()).isEqualTo(maybeAssessment.get().getSelectionAlgorithm());
+
+        Form form1 = null;
+        Form form2 = null;
+        Form form3 = null;
+
+        for(Form form : seg.getForms()) {
+            switch (form.getKey()) {
+                case "187-510":
+                    form1 = form;
+                    break;
+                case "187-511":
+                    form2 = form;
+                    break;
+                case "187-512":
+                    form3 = form;
+                    break;
+            }
+        }
+        assertThat(seg.getForms()).hasSize(3);
+        assertThat(form1.getKey()).isEqualTo("187-510");
+        assertThat(form1.getCohort()).isEqualTo("Default");
+        assertThat(form1.getId()).isEqualTo("PracTest::MG4::S1::SP14");
+        assertThat(form1.getLanguage()).isEqualTo("ENU");
+        assertThat(form1.getLoadVersion()).isEqualTo(8233L);
+        assertThat(form1.getUpdateVersion()).isNull();
+        assertThat(form1.getSegmentKey()).isEqualTo("(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016");
+        assertThat(form2.getKey()).isEqualTo("187-511");
+        assertThat(form2.getCohort()).isEqualTo("Default");
+        assertThat(form2.getId()).isEqualTo("PracTest::MG4::S1::SP14::Braille");
+        assertThat(form2.getLanguage()).isEqualTo("ENU-Braille");
+        assertThat(form2.getLoadVersion()).isEqualTo(8233L);
+        assertThat(form2.getUpdateVersion()).isNull();
+        assertThat(form2.getSegmentKey()).isEqualTo("(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016");
+        assertThat(form3.getKey()).isEqualTo("187-512");
+        assertThat(form3.getCohort()).isEqualTo("Default");
+        assertThat(form3.getId()).isEqualTo("PracTest::MG4::S1::SP14::ESN");
+        assertThat(form3.getLanguage()).isEqualTo("ESN");
+        assertThat(form3.getLoadVersion()).isEqualTo(8233L);
+        assertThat(form3.getUpdateVersion()).isNull();
+        assertThat(form3.getSegmentKey()).isEqualTo("(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016");
     }
 
     @Test
@@ -126,6 +188,9 @@ public class AssessmentQueryRepositoryImplIntegrationTests {
         assertThat(segment1.getKey()).isEqualTo("(SBAC_PT)SBAC-SEG1-MATH-8-Spring-2013-2015");
         assertThat(segment1.getSegmentId()).isEqualTo("SBAC-SEG1-MATH-8");
         assertThat(segment1.getSelectionAlgorithm()).isEqualTo("fixedform");
+        assertThat(segment1.getPosition()).isEqualTo(1);
+        assertThat(segment1.getMinItems()).isEqualTo(4);
+        assertThat(segment1.getMaxItems()).isEqualTo(4);
         assertThat(segment1.getSubject()).isEqualTo(subject);
         assertThat(segment1.getStartAbility()).isEqualTo(0);
 
@@ -134,9 +199,94 @@ public class AssessmentQueryRepositoryImplIntegrationTests {
         assertThat(segment2.getKey()).isEqualTo("(SBAC_PT)SBAC-SEG2-MATH-8-Spring-2013-2015");
         assertThat(segment2.getSegmentId()).isEqualTo("SBAC-SEG2-MATH-8");
         assertThat(segment2.getSelectionAlgorithm()).isEqualTo("fixedform");
+        assertThat(segment2.getPosition()).isEqualTo(2);
+        assertThat(segment2.getMinItems()).isEqualTo(4);
+        assertThat(segment2.getMaxItems()).isEqualTo(4);
         assertThat(segment2.getSubject()).isEqualTo(subject);
         assertThat(segment2.getLanguages()).hasSize(2);
         assertThat(segment2.getLanguages()).contains(new Property("Language", "ENU"), new Property("Language", "Braille-ENU"));
         assertThat(segment2.getStartAbility()).isEqualTo(0);
+
+        List<Form> formsSeg1 = segment1.getForms();
+        assertThat(formsSeg1.size()).isEqualTo(3);
+        List<Form> formsSeg2 = segment2.getForms();
+        assertThat(formsSeg2.size()).isEqualTo(3);
+
+        List<Form> allSegments = new ArrayList<>();
+        allSegments.addAll(formsSeg1);
+        allSegments.addAll(formsSeg2);
+        Form form1 = null;
+        Form form2 = null;
+        Form form3 = null;
+        Form form4 = null;
+        Form form5 = null;
+        Form form6 = null;
+
+        for(Form form : allSegments) {
+            switch (form.getKey()) {
+                case "187-528":
+                    form1 = form;
+                    break;
+                case "187-529":
+                    form2 = form;
+                    break;
+                case "187-530":
+                    form3 = form;
+                    break;
+                case "187-531":
+                    form4 = form;
+                    break;
+                case "187-532":
+                    form5 = form;
+                    break;
+                case "187-533":
+                    form6 = form;
+                    break;
+            }
+        }
+
+        assertThat(form1.getKey()).isEqualTo("187-528");
+        assertThat(form1.getCohort()).isEqualTo("Default");
+        assertThat(form1.getId()).isEqualTo("PracTest::MG8::S1::SP14");
+        assertThat(form1.getLanguage()).isEqualTo("ENU");
+        assertThat(form1.getLoadVersion()).isEqualTo(8233L);
+        assertThat(form1.getUpdateVersion()).isEqualTo(8234L);
+        assertThat(form1.getSegmentKey()).isEqualTo("(SBAC_PT)SBAC-SEG1-MATH-8-Spring-2013-2015");
+        assertThat(form2.getKey()).isEqualTo("187-529");
+        assertThat(form2.getCohort()).isEqualTo("Default");
+        assertThat(form2.getId()).isEqualTo("PracTest::MG8::S1::SP14::Braille");
+        assertThat(form2.getLanguage()).isEqualTo("ENU-Braille");
+        assertThat(form2.getLoadVersion()).isEqualTo(8233L);
+        assertThat(form2.getUpdateVersion()).isEqualTo(8234L);
+        assertThat(form2.getSegmentKey()).isEqualTo("(SBAC_PT)SBAC-SEG1-MATH-8-Spring-2013-2015");
+        assertThat(form3.getKey()).isEqualTo("187-530");
+        assertThat(form3.getCohort()).isEqualTo("Default");
+        assertThat(form3.getId()).isEqualTo("PracTest::MG8::S1::SP14::ESN");
+        assertThat(form3.getLanguage()).isEqualTo("ESN");
+        assertThat(form3.getLoadVersion()).isEqualTo(8233L);
+        assertThat(form3.getUpdateVersion()).isEqualTo(8234L);
+        assertThat(form3.getSegmentKey()).isEqualTo("(SBAC_PT)SBAC-SEG1-MATH-8-Spring-2013-2015");
+        assertThat(form4.getKey()).isEqualTo("187-531");
+        assertThat(form4.getCohort()).isEqualTo("Default");
+        assertThat(form4.getId()).isEqualTo("PracTest::MG8::S2::SP14");
+        assertThat(form4.getLanguage()).isEqualTo("ENU");
+        assertThat(form4.getLoadVersion()).isEqualTo(8233L);
+        assertThat(form4.getUpdateVersion()).isNull();
+        assertThat(form4.getSegmentKey()).isEqualTo("(SBAC_PT)SBAC-SEG2-MATH-8-Spring-2013-2015");
+        assertThat(form5.getKey()).isEqualTo("187-532");
+        assertThat(form5.getCohort()).isEqualTo("Default");
+        assertThat(form5.getId()).isEqualTo("PracTest::MG8::S2::SP14::Braille");
+        assertThat(form5.getLanguage()).isEqualTo("ENU-Braille");
+        assertThat(form5.getLoadVersion()).isEqualTo(8233L);
+        assertThat(form5.getUpdateVersion()).isNull();
+        assertThat(form5.getSegmentKey()).isEqualTo("(SBAC_PT)SBAC-SEG2-MATH-8-Spring-2013-2015");
+        assertThat(form6.getKey()).isEqualTo("187-533");
+        assertThat(form6.getCohort()).isEqualTo("Default");
+        assertThat(form6.getId()).isEqualTo("PracTest::MG8::S2::SP14::ESN");
+        assertThat(form6.getLanguage()).isEqualTo("ESN");
+        assertThat(form6.getLoadVersion()).isEqualTo(8233L);
+        assertThat(form6.getUpdateVersion()).isNull();
+        assertThat(form6.getSegmentKey()).isEqualTo("(SBAC_PT)SBAC-SEG2-MATH-8-Spring-2013-2015");
     }
+
 }

--- a/service/src/test/java/tds/assessment/repositories/AssessmentQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/assessment/repositories/AssessmentQueryRepositoryImplIntegrationTests.java
@@ -119,20 +119,10 @@ public class AssessmentQueryRepositoryImplIntegrationTests {
         assertThat(seg.getSelectionAlgorithm()).isEqualTo(maybeAssessment.get().getSelectionAlgorithm());
 
         Form form1 = null;
-        Form form2 = null;
-        Form form3 = null;
 
         for(Form form : seg.getForms()) {
-            switch (form.getKey()) {
-                case "187-510":
-                    form1 = form;
-                    break;
-                case "187-511":
-                    form2 = form;
-                    break;
-                case "187-512":
-                    form3 = form;
-                    break;
+            if (form.getKey().equals("187-510")) {
+                form1 = form;
             }
         }
         assertThat(seg.getForms()).hasSize(3);
@@ -143,20 +133,6 @@ public class AssessmentQueryRepositoryImplIntegrationTests {
         assertThat(form1.getLoadVersion()).isEqualTo(8233L);
         assertThat(form1.getUpdateVersion()).isNull();
         assertThat(form1.getSegmentKey()).isEqualTo("(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016");
-        assertThat(form2.getKey()).isEqualTo("187-511");
-        assertThat(form2.getCohort()).isEqualTo("Default");
-        assertThat(form2.getId()).isEqualTo("PracTest::MG4::S1::SP14::Braille");
-        assertThat(form2.getLanguage()).isEqualTo("ENU-Braille");
-        assertThat(form2.getLoadVersion()).isEqualTo(8233L);
-        assertThat(form2.getUpdateVersion()).isNull();
-        assertThat(form2.getSegmentKey()).isEqualTo("(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016");
-        assertThat(form3.getKey()).isEqualTo("187-512");
-        assertThat(form3.getCohort()).isEqualTo("Default");
-        assertThat(form3.getId()).isEqualTo("PracTest::MG4::S1::SP14::ESN");
-        assertThat(form3.getLanguage()).isEqualTo("ESN");
-        assertThat(form3.getLoadVersion()).isEqualTo(8233L);
-        assertThat(form3.getUpdateVersion()).isNull();
-        assertThat(form3.getSegmentKey()).isEqualTo("(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016");
     }
 
     @Test
@@ -217,30 +193,13 @@ public class AssessmentQueryRepositoryImplIntegrationTests {
         allSegments.addAll(formsSeg2);
         Form form1 = null;
         Form form2 = null;
-        Form form3 = null;
-        Form form4 = null;
-        Form form5 = null;
-        Form form6 = null;
-
         for(Form form : allSegments) {
             switch (form.getKey()) {
                 case "187-528":
                     form1 = form;
                     break;
-                case "187-529":
-                    form2 = form;
-                    break;
-                case "187-530":
-                    form3 = form;
-                    break;
                 case "187-531":
-                    form4 = form;
-                    break;
-                case "187-532":
-                    form5 = form;
-                    break;
-                case "187-533":
-                    form6 = form;
+                    form2 = form;
                     break;
             }
         }
@@ -252,41 +211,13 @@ public class AssessmentQueryRepositoryImplIntegrationTests {
         assertThat(form1.getLoadVersion()).isEqualTo(8233L);
         assertThat(form1.getUpdateVersion()).isEqualTo(8234L);
         assertThat(form1.getSegmentKey()).isEqualTo("(SBAC_PT)SBAC-SEG1-MATH-8-Spring-2013-2015");
-        assertThat(form2.getKey()).isEqualTo("187-529");
+        assertThat(form2.getKey()).isEqualTo("187-531");
         assertThat(form2.getCohort()).isEqualTo("Default");
-        assertThat(form2.getId()).isEqualTo("PracTest::MG8::S1::SP14::Braille");
-        assertThat(form2.getLanguage()).isEqualTo("ENU-Braille");
+        assertThat(form2.getId()).isEqualTo("PracTest::MG8::S2::SP14");
+        assertThat(form2.getLanguage()).isEqualTo("ENU");
         assertThat(form2.getLoadVersion()).isEqualTo(8233L);
-        assertThat(form2.getUpdateVersion()).isEqualTo(8234L);
-        assertThat(form2.getSegmentKey()).isEqualTo("(SBAC_PT)SBAC-SEG1-MATH-8-Spring-2013-2015");
-        assertThat(form3.getKey()).isEqualTo("187-530");
-        assertThat(form3.getCohort()).isEqualTo("Default");
-        assertThat(form3.getId()).isEqualTo("PracTest::MG8::S1::SP14::ESN");
-        assertThat(form3.getLanguage()).isEqualTo("ESN");
-        assertThat(form3.getLoadVersion()).isEqualTo(8233L);
-        assertThat(form3.getUpdateVersion()).isEqualTo(8234L);
-        assertThat(form3.getSegmentKey()).isEqualTo("(SBAC_PT)SBAC-SEG1-MATH-8-Spring-2013-2015");
-        assertThat(form4.getKey()).isEqualTo("187-531");
-        assertThat(form4.getCohort()).isEqualTo("Default");
-        assertThat(form4.getId()).isEqualTo("PracTest::MG8::S2::SP14");
-        assertThat(form4.getLanguage()).isEqualTo("ENU");
-        assertThat(form4.getLoadVersion()).isEqualTo(8233L);
-        assertThat(form4.getUpdateVersion()).isNull();
-        assertThat(form4.getSegmentKey()).isEqualTo("(SBAC_PT)SBAC-SEG2-MATH-8-Spring-2013-2015");
-        assertThat(form5.getKey()).isEqualTo("187-532");
-        assertThat(form5.getCohort()).isEqualTo("Default");
-        assertThat(form5.getId()).isEqualTo("PracTest::MG8::S2::SP14::Braille");
-        assertThat(form5.getLanguage()).isEqualTo("ENU-Braille");
-        assertThat(form5.getLoadVersion()).isEqualTo(8233L);
-        assertThat(form5.getUpdateVersion()).isNull();
-        assertThat(form5.getSegmentKey()).isEqualTo("(SBAC_PT)SBAC-SEG2-MATH-8-Spring-2013-2015");
-        assertThat(form6.getKey()).isEqualTo("187-533");
-        assertThat(form6.getCohort()).isEqualTo("Default");
-        assertThat(form6.getId()).isEqualTo("PracTest::MG8::S2::SP14::ESN");
-        assertThat(form6.getLanguage()).isEqualTo("ESN");
-        assertThat(form6.getLoadVersion()).isEqualTo(8233L);
-        assertThat(form6.getUpdateVersion()).isNull();
-        assertThat(form6.getSegmentKey()).isEqualTo("(SBAC_PT)SBAC-SEG2-MATH-8-Spring-2013-2015");
+        assertThat(form2.getUpdateVersion()).isNull();
+        assertThat(form2.getSegmentKey()).isEqualTo("(SBAC_PT)SBAC-SEG2-MATH-8-Spring-2013-2015");
     }
 
 }

--- a/service/src/test/resources/db/migration/V1478285069__itembank_create_testform.sql
+++ b/service/src/test/resources/db/migration/V1478285069__itembank_create_testform.sql
@@ -1,0 +1,27 @@
+/***********************************************************************************************************************
+  File: V1478285069__itembank_create_testform.sql
+
+  Desc: Create the testform storing assessment form properties.
+
+***********************************************************************************************************************/
+
+use itembank;
+
+DROP TABLE IF EXISTS tblitemprops;
+
+CREATE TABLE `testform` (
+  `_fk_adminsubject` varchar(250) NOT NULL,
+  `_efk_itsbank` bigint(20) NOT NULL,
+  `_efk_itskey` bigint(20) NOT NULL,
+  `formid` varchar(150) DEFAULT NULL,
+  `language` varchar(150) DEFAULT NULL,
+  `_key` varchar(100) NOT NULL,
+  `itsid` varchar(150) DEFAULT NULL,
+  `iteration` int(11) NOT NULL DEFAULT '0',
+  `loadconfig` bigint(20) DEFAULT NULL,
+  `updateconfig` bigint(20) DEFAULT NULL,
+  `cohort` varchar(20) NOT NULL DEFAULT 'default',
+  PRIMARY KEY (`_key`),
+  KEY `fk_testform_tblsetofadminsubjects` (`_fk_adminsubject`),
+  CONSTRAINT `fk_testform_tblsetofadminsubjects` FOREIGN KEY (`_fk_adminsubject`) REFERENCES `tblsetofadminsubjects` (`_key`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Forms are now retrieved in the AssessmentQueryRepository.findByKey() method. List of forms are passed into the Mapper, which will assign the forms to the appropriate segments before returning the entire Assessment.

Multiple legacy table columns that seemingly aren't used have been excluded from the port. 

Examples of usage in legacy app:
ItemBankDaoImpl - line 109
StudentDLL - line 4054, 4065

Eventually, Form should have a collection of Items as well. Perhaps we can explore using Hibernate  or some other ORM framework.