### PR TITLE
Bugfix for filtering items based on language when getting all items i…

### DIFF
--- a/client/src/main/java/tds/assessment/Item.java
+++ b/client/src/main/java/tds/assessment/Item.java
@@ -5,6 +5,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import tds.accommodation.Accommodation;
+
 /**
  * A model representing an item for an {@link tds.assessment.Assessment}
  */
@@ -210,6 +212,21 @@ public class Item {
 
     public void setFormKeys(Set<String> formKeys) {
         this.formKeys = formKeys;
+    }
+
+    /**
+     * Finds the language code of the item based on its item properties.
+     *
+     * @return The language code of the item if one exists in its properties - otherwise null
+     */
+    public String getLanguageCode() {
+        for (ItemProperty property : itemProperties) {
+            if (Accommodation.ACCOMMODATION_TYPE_LANGUAGE.equalsIgnoreCase(property.getName())) {
+                return property.getValue();
+            }
+        }
+
+        return null;
     }
 
     @Override

--- a/client/src/main/java/tds/assessment/Segment.java
+++ b/client/src/main/java/tds/assessment/Segment.java
@@ -328,7 +328,11 @@ public class Segment {
                 retItems.addAll(form.getItems());
             }
         } else {
-            retItems = items;
+            for (Item item : items) {
+                if (languageCode.equalsIgnoreCase(item.getLanguageCode())) {
+                    retItems.add(item);
+                }
+            }
         }
 
         return retItems;

--- a/service/src/test/java/tds/assessment/services/impl/AssessmentAssemblerTest.java
+++ b/service/src/test/java/tds/assessment/services/impl/AssessmentAssemblerTest.java
@@ -579,7 +579,7 @@ public class AssessmentAssemblerTest {
         Segment retSeg1 = retSegments.get(0);
         assertThat(retSeg1.getKey()).isEqualTo("seg1");
         List<Item> retSeg1Items = retSeg1.getItems("lang1");
-        assertThat(retSeg1Items).hasSize(2);
+        assertThat(retSeg1Items).hasSize(1);
 
         // Seg 1 Items + item props
         Item retSeg1Item1 = retSeg1Items.get(0);
@@ -603,7 +603,9 @@ public class AssessmentAssemblerTest {
         assertThat(retSeg1Item1Prop.get(2).getValue()).isEqualTo("lang1");
         assertThat(retSeg1Item1Prop.get(2).getDescription()).isEqualTo("desc4");
 
-        Item retSeg1Item2 = retSeg1Items.get(1);
+        retSeg1Items = retSeg1.getItems("lang2");
+        assertThat(retSeg1Items).hasSize(1);
+        Item retSeg1Item2 = retSeg1Items.get(0);
         List<ItemProperty> retSeg1Item2Prop = retSeg1Item2.getItemProperties();
         assertThat(retSeg1Item2Prop).hasSize(1);
         assertThat(retSeg1Item2Prop.get(0).getItemId()).isEqualTo("item2");


### PR DESCRIPTION
…n a segment for a specified language (Adaptive)

Previously, for adaptive segments, we were returning the full list of possible items in the segment (which could potentially include items from other languages). This bugfix will ensure we only retrieve items for the specified language.

Please see TDS-692 for more details