### PR TITLE
Remove assessment from configs/itembank tables

### DIFF
--- a/service/src/main/java/tds/assessment/repositories/AssessmentCommandRepository.java
+++ b/service/src/main/java/tds/assessment/repositories/AssessmentCommandRepository.java
@@ -1,0 +1,29 @@
+/***************************************************************************************************
+ * Copyright 2017 Regents of the University of California. Licensed under the Educational
+ * Community License, Version 2.0 (the “license”); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required under applicable law or agreed to in writing, software distributed under the
+ * License is distributed in an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for specific language governing permissions
+ * and limitations under the license.
+ **************************************************************************************************/
+
+package tds.assessment.repositories;
+
+import tds.assessment.Assessment;
+
+/**
+ * A repository for writing and deleting {@link tds.assessment.Assessment} data
+ */
+public interface AssessmentCommandRepository {
+    /**
+     * Removes {@link tds.assessment.Assessment} data from the TDS database
+     *
+     * @param clientName The name of the client/publisher
+     * @param assessment The {@link tds.assessment.Assessment} object to delete
+     */
+    void removeAssessmentData(final String clientName, final Assessment assessment);
+}

--- a/service/src/main/java/tds/assessment/repositories/impl/AssessmentCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/assessment/repositories/impl/AssessmentCommandRepositoryImpl.java
@@ -1,0 +1,140 @@
+/***************************************************************************************************
+ * Copyright 2017 Regents of the University of California. Licensed under the Educational
+ * Community License, Version 2.0 (the “license”); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required under applicable law or agreed to in writing, software distributed under the
+ * License is distributed in an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for specific language governing permissions
+ * and limitations under the license.
+ **************************************************************************************************/
+
+package tds.assessment.repositories.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import tds.assessment.Assessment;
+import tds.assessment.repositories.AssessmentCommandRepository;
+
+@Repository
+public class AssessmentCommandRepositoryImpl implements AssessmentCommandRepository {
+    private final JdbcTemplate jdbcTemplate;
+    private static final String[] ITEMBANK_TABLE_NAMES = {
+        "aa_itemcl",
+        "tblsetofitemstrands",
+        "tblsetofitemstimuli",
+        "tblitemprops",
+        "setoftestgrades",
+        "testcohort",
+        "tblitemselectionparm",
+        "tbladminstrand",
+        "tblsetofadminitems",
+        "itemscoredimension",
+        "tbladminstimulus",
+        "testform",
+        "testformitem",
+        "affinitygroup",
+        "affinitygroupitem",
+        "tblsetofadminsubjects"
+    };
+
+    private static final String[] CONFIGS_TABLE_NAMES = {
+        "client_testmode",
+        "client_testformproperties",
+        "client_testwindow",
+        "client_testgrades",
+        "client_testeligibility",
+        "client_test_itemtypes",
+        "client_test_itemconstraint",
+        "client_testtooltype",
+        "client_segmentproperties",
+        "client_testproperties"
+    };
+
+    @Autowired
+    public AssessmentCommandRepositoryImpl(final JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void removeAssessmentData(final String clientName, final Assessment assessment) {
+        final List<String> SQL = generateItembankDeleteSQL(assessment.getKey());
+        SQL.addAll(generateConfigsDeleteSQL(clientName, assessment.getAssessmentId()));
+
+        jdbcTemplate.batchUpdate(SQL.toArray(new String[SQL.size()]));
+    }
+
+    private List<String> generateItembankDeleteSQL(final String assessmentKey) {
+        final List<String> SQL = Arrays.stream(ITEMBANK_TABLE_NAMES)
+            .map(table -> table.equals("tblsetofadminsubjects")
+                ? String.format("DELETE FROM itembank.%s WHERE _key = '%s';", table, assessmentKey)
+                : String.format("DELETE FROM itembank.%s WHERE _fk_adminsubject = '%s';", table, assessmentKey))
+            .collect(Collectors.toList());
+
+        // Delete items that are not being used by any assessment
+        SQL.add(
+            "DELETE FROM \n" +
+                "   tblitem \n" +
+                "WHERE \n" +
+                "   _key NOT IN ( \n" +
+                "   SELECT \n" +
+                "       _fk_item \n" +
+                "   FROM \n" +
+                "       tblsetofadminitems \n" +
+                "   );"
+        );
+
+        // Delete stimuli that are not being used by any assessment
+        SQL.add(
+            "DELETE FROM \n" +
+                "   tblstimulus  \n" +
+                "WHERE \n" +
+                "   _key NOT IN ( \n" +
+                "   SELECT \n" +
+                "       _fk_stimulus \n" +
+                "   FROM \n" +
+                "       tblsetofitemstimuli \n" +
+                ");"
+        );
+
+        // Delete strands that are not being used by any assessment
+        SQL.add(
+            "DELETE FROM \n" +
+                "   tblstrand \n" +
+                "WHERE \n" +
+                "   _key NOT IN ( \n" +
+                "   SELECT \n" +
+                "       _fk_strand \n" +
+                "   FROM \n" +
+                "       tbladminstrand \n" +
+                ");"
+        );
+
+        return SQL;
+    }
+
+    private List<String> generateConfigsDeleteSQL(final String clientName, final String assessmentId) {
+        final List<String> SQL = Arrays.stream(CONFIGS_TABLE_NAMES)
+            .map(table -> {
+                switch (table) {
+                    case "client_segmentproperties":
+                        return String.format("DELETE FROM configs.%s WHERE clientname = '%s' AND parenttest = '%s';", table, clientName, assessmentId);
+                    case "client_testtooltype":
+                        return String.format("DELETE FROM configs.%s WHERE clientname = '%s' AND context = '%s';", table, clientName, assessmentId);
+                    default:
+                        return String.format("DELETE FROM configs.%s WHERE clientname = '%s' AND testid = '%s';", table, clientName, assessmentId);
+                }
+            })
+            .collect(Collectors.toList());
+
+        return SQL;
+    }
+}

--- a/service/src/main/java/tds/assessment/services/AssessmentService.java
+++ b/service/src/main/java/tds/assessment/services/AssessmentService.java
@@ -33,8 +33,17 @@ public interface AssessmentService {
 
     /**
      * Finds an assessment by the segment key including single segmented assessments
+     *
      * @param segmentKey the segment key
      * @return optional with {@link tds.assessment.Assessment} if found otherwise empty
      */
     Optional<Assessment> findAssessmentBySegmentKey(final String segmentKey);
+
+    /**
+     * Deletes an {@link tds.assessment.Assessment} with the specified key and client name
+     *
+     * @param clientName the client environment identifier
+     * @param key        the key of the {@link tds.assessment.Assessment}
+     */
+    void removeAssessment(final String clientName, final String key);
 }

--- a/service/src/main/java/tds/assessment/web/endpoints/AssessmentController.java
+++ b/service/src/main/java/tds/assessment/web/endpoints/AssessmentController.java
@@ -14,8 +14,10 @@
 package tds.assessment.web.endpoints;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -46,13 +48,18 @@ class AssessmentController {
      */
     @GetMapping(value = "/{clientName}/assessments/{key}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    ResponseEntity<Assessment> findAssessment(@PathVariable final String clientName, @PathVariable final String key)
-        throws NotFoundException {
+    ResponseEntity<Assessment> findAssessment(@PathVariable final String clientName,
+                                              @PathVariable final String key) throws NotFoundException {
         final Assessment assessment = service.findAssessment(clientName, key)
             .orElseThrow(() -> new NotFoundException("Could not find set of admin subject for %s", key));
 
         return ResponseEntity.ok(assessment);
     }
 
-
+    @DeleteMapping(value = "/{clientName}/assessments/{key}", produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<?> removeAssessment(@PathVariable final String clientName,
+                                       @PathVariable final String key) throws NotFoundException {
+        service.removeAssessment(clientName, key);
+        return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
+    }
 }

--- a/service/src/test/java/tds/assessment/repositories/impl/AssessmentCommandRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/assessment/repositories/impl/AssessmentCommandRepositoryImplIntegrationTests.java
@@ -1,0 +1,74 @@
+/***************************************************************************************************
+ * Copyright 2017 Regents of the University of California. Licensed under the Educational
+ * Community License, Version 2.0 (the “license”); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required under applicable law or agreed to in writing, software distributed under the
+ * License is distributed in an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for specific language governing permissions
+ * and limitations under the license.
+ **************************************************************************************************/
+
+package tds.assessment.repositories.impl;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.Resource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import tds.assessment.Assessment;
+import tds.assessment.repositories.AssessmentCommandRepository;
+import tds.assessment.repositories.AssessmentQueryRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
+@Transactional
+public class AssessmentCommandRepositoryImplIntegrationTests {
+    private static final String TEST_CLIENT_NAME = "SBAC_PT";
+    private static final String TEST_ASSESSMENT_KEY = "(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016";
+
+    @Autowired
+    private AssessmentCommandRepository commandRepository;
+
+    @Autowired
+    private AssessmentQueryRepository queryRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Value("classpath:(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016.xml")
+    private Resource res;
+
+    @Before
+    public void setup() throws IOException {
+        // Loads the test package
+        jdbcTemplate.execute(String.format("CALL itembank.loader_main('%s')", Files.toString(res.getFile(), Charsets.UTF_8)));
+    }
+
+    @Test
+    public void testRepository() {
+        Optional<Assessment> assessment = queryRepository.findAssessmentByKey(TEST_CLIENT_NAME, TEST_ASSESSMENT_KEY);
+        assertThat(assessment.isPresent()).isTrue();
+
+        commandRepository.removeAssessmentData(TEST_CLIENT_NAME, assessment.get());
+
+        Optional<Assessment> retAssessment = queryRepository.findAssessmentByKey(TEST_CLIENT_NAME, TEST_ASSESSMENT_KEY);
+        assertThat(retAssessment.isPresent()).isFalse();
+    }
+}

--- a/service/src/test/java/tds/assessment/web/endpoints/AssessmentControllerTest.java
+++ b/service/src/test/java/tds/assessment/web/endpoints/AssessmentControllerTest.java
@@ -78,4 +78,12 @@ public class AssessmentControllerTest {
         when(service.findAssessment(clientName, assessmentKey)).thenReturn(Optional.empty());
         controller.findAssessment(clientName, assessmentKey);
     }
+
+    @Test
+    public void shouldRemoveAssessment() {
+        final String clientName = "SBAC_PT";
+        final String assessmentKey = "theKey";
+        controller.removeAssessment(clientName, assessmentKey);
+        verify(service).removeAssessment(clientName, assessmentKey);
+    }
 }

--- a/service/src/test/resources/(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016.xml
+++ b/service/src/test/resources/(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016.xml
@@ -1,0 +1,684 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testspecification purpose="administration" publisher="SBAC_PT" publishdate="Aug 19 2015  3:44PM" version="1.0">
+  <identifier uniqueid="(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016" name="SBAC-IRP-CAT-ELA-3" label="Grade 3 ELA" version="8185" />
+  <property name="subject" value="ELA" label="ELA" />
+  <property name="grade" value="3" label="grade 3" />
+  <property name="type" value="summative" label="summative" />
+  <administration>
+    <testblueprint>
+      <bpelement elementtype="test" minopitems="8" maxopitems="8" minftitems="0" maxftitems="0" opitemcount="18" ftitemcount="0">
+        <identifier uniqueid="(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016" name="SBAC-IRP-CAT-ELA-3" version="8185" />
+      </bpelement>
+      <bpelement elementtype="segment" minopitems="8" maxopitems="8" minftitems="0" maxftitems="0" opitemcount="18" ftitemcount="0">
+        <identifier uniqueid="(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016" name="SBAC-IRP-CAT-ELA-3" version="8185" />
+      </bpelement>
+      <bpelement elementtype="affinitygroup" minopitems="1" maxopitems="1" opitemcount="3" ftitemcount="0">
+        <identifier uniqueid="G3_Claim1_T2/12" name="G3_Claim1_T2/12" version="8185" />
+      </bpelement>
+      <bpelement elementtype="affinitygroup" minopitems="2" maxopitems="8" opitemcount="9" ftitemcount="0">
+        <identifier uniqueid="G3_DOK2" name="G3_DOK2" version="8185" />
+      </bpelement>
+      <bpelement elementtype="strand" minopitems="2" maxopitems="2" opitemcount="5" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-1-IT" name="1-IT" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-1-IT" minopitems="0" maxopitems="2" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-1-IT|10-3" name="1-IT|10-3" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-1-IT|10-3" minopitems="0" maxopitems="2" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-1-IT|10-3|3.RI.4" name="1-IT|10-3|3.RI.4" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-1-IT" minopitems="0" maxopitems="2" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-1-IT|11-KG" name="1-IT|11-KG" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-1-IT" minopitems="0" maxopitems="2" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-1-IT|12-3" name="1-IT|12-3" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-1-IT" minopitems="0" maxopitems="2" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-1-IT|13-3" name="1-IT|13-3" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-1-IT|13-3" minopitems="0" maxopitems="2" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-1-IT|13-3|3.RI.5" name="1-IT|13-3|3.RI.5" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-1-IT" minopitems="0" maxopitems="2" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-1-IT|8-3" name="1-IT|8-3" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-1-IT|8-3" minopitems="0" maxopitems="2" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-1-IT|8-3|3.RI.1" name="1-IT|8-3|3.RI.1" version="8185" />
+      </bpelement>
+      <bpelement elementtype="strand" minopitems="2" maxopitems="2" opitemcount="4" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-1-LT" name="1-LT" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-1-LT" minopitems="0" maxopitems="2" opitemcount="2" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-1-LT|2-3" name="1-LT|2-3" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-1-LT|2-3" minopitems="0" maxopitems="2" opitemcount="2" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-1-LT|2-3|3.RL.2" name="1-LT|2-3|3.RL.2" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-1-LT" minopitems="0" maxopitems="2" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-1-LT|6-3" name="1-LT|6-3" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-1-LT|6-3" minopitems="0" maxopitems="2" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-1-LT|6-3|3.RL.5" name="1-LT|6-3|3.RL.5" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-1-LT" minopitems="0" maxopitems="2" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-1-LT|7-3" name="1-LT|7-3" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-1-LT|7-3" minopitems="0" maxopitems="2" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-1-LT|7-3|3.L.5a" name="1-LT|7-3|3.L.5a" version="8185" />
+      </bpelement>
+      <bpelement elementtype="strand" minopitems="1" maxopitems="1" opitemcount="4" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-2-W" name="2-W" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-2-W" minopitems="0" maxopitems="1" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-2-W|1-3" name="2-W|1-3" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-2-W|1-3" minopitems="0" maxopitems="1" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-2-W|1-3|3.W.3a" name="2-W|1-3|3.W.3a" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-2-W" minopitems="0" maxopitems="1" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-2-W|3-3" name="2-W|3-3" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-2-W|3-3" minopitems="0" maxopitems="1" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-2-W|3-3|3.W.2a" name="2-W|3-3|3.W.2a" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-2-W" minopitems="0" maxopitems="1" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-2-W|8-3" name="2-W|8-3" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-2-W|8-3" minopitems="0" maxopitems="1" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-2-W|8-3|3.L.6" name="2-W|8-3|3.L.6" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-2-W" minopitems="0" maxopitems="1" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-2-W|9-3" name="2-W|9-3" version="8185" />
+      </bpelement>
+      <bpelement elementtype="strand" minopitems="0" maxopitems="2" opitemcount="3" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-3-L" name="3-L" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-3-L" minopitems="0" maxopitems="2" opitemcount="3" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-3-L|4-3" name="3-L|4-3" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-3-L|4-3" minopitems="0" maxopitems="2" opitemcount="3" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-3-L|4-3|3.SL.2" name="3-L|4-3|3.SL.2" version="8185" />
+      </bpelement>
+      <bpelement elementtype="strand" minopitems="1" maxopitems="1" opitemcount="2" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-4-CR" name="4-CR" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-4-CR" minopitems="0" maxopitems="1" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-4-CR|2-3" name="4-CR|2-3" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-4-CR|2-3" minopitems="0" maxopitems="1" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-4-CR|2-3|3.W.8" name="4-CR|2-3|3.W.8" version="8185" />
+      </bpelement>
+      <bpelement elementtype="contentlevel" parentid="SBAC_PT-4-CR" minopitems="0" maxopitems="1" opitemcount="1" ftitemcount="0">
+        <identifier uniqueid="SBAC_PT-4-CR|3-1" name="4-CR|3-1" version="8185" />
+      </bpelement>
+    </testblueprint>
+    <poolproperty property="--ITEMTYPE--" value="EBSR" label="EBSR" itemcount="3" />
+    <poolproperty property="--ITEMTYPE--" value="HTQ" label="HTQ" itemcount="4" />
+    <poolproperty property="--ITEMTYPE--" value="MC" label="MC" itemcount="6" />
+    <poolproperty property="--ITEMTYPE--" value="MI" label="MI" itemcount="2" />
+    <poolproperty property="--ITEMTYPE--" value="MS" label="MS" itemcount="3" />
+    <poolproperty property="Language" value="ENU" label="English" itemcount="18" />
+    <itempool>
+      <passage filename="stim-187-3732.xml">
+        <identifier uniqueid="187-3732" version="8185" />
+      </passage>
+      <passage filename="stim-187-3739.xml">
+        <identifier uniqueid="187-3739" version="8185" />
+      </passage>
+      <passage filename="stim-187-3753.xml">
+        <identifier uniqueid="187-3753" version="8185" />
+      </passage>
+      <testitem filename="item-187-2458.xml" itemtype="EBSR">
+        <identifier uniqueid="187-2458" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>SBAC_PT-3-L</bpref>
+        <bpref>SBAC_PT-3-L|4-3</bpref>
+        <bpref>SBAC_PT-3-L|4-3|3.SL.2</bpref>
+        <passageref>187-3732</passageref>
+        <poolproperty property="--ITEMTYPE--" value="EBSR" label="EBSR" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="1.000000000000000e+000" />
+          <itemscoreparameter measurementparameter="b" value="1.000000000000000e-015" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2463.xml" itemtype="MC">
+        <identifier uniqueid="187-2463" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>G3_DOK2</bpref>
+        <bpref>SBAC_PT-4-CR</bpref>
+        <bpref>SBAC_PT-4-CR|3-1</bpref>
+        <poolproperty property="--ITEMTYPE--" value="MC" label="MC" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="1.000000000000000e+000" />
+          <itemscoreparameter measurementparameter="b" value="1.000000000000000e-015" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2467.xml" itemtype="MC">
+        <identifier uniqueid="187-2467" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>G3_DOK2</bpref>
+        <bpref>SBAC_PT-3-L</bpref>
+        <bpref>SBAC_PT-3-L|4-3</bpref>
+        <bpref>SBAC_PT-3-L|4-3|3.SL.2</bpref>
+        <passageref>187-3732</passageref>
+        <poolproperty property="--ITEMTYPE--" value="MC" label="MC" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="1.000000000000000e+000" />
+          <itemscoreparameter measurementparameter="b" value="1.000000000000000e-015" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2493.xml" itemtype="EBSR">
+        <identifier uniqueid="187-2493" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>G3_Claim1_T2/12</bpref>
+        <bpref>G3_DOK2</bpref>
+        <bpref>SBAC_PT-1-LT</bpref>
+        <bpref>SBAC_PT-1-LT|2-3</bpref>
+        <bpref>SBAC_PT-1-LT|2-3|3.RL.2</bpref>
+        <passageref>187-3739</passageref>
+        <poolproperty property="--ITEMTYPE--" value="EBSR" label="EBSR" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="1.000000000000000e+000" />
+          <itemscoreparameter measurementparameter="b" value="1.000000000000000e-015" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2497.xml" itemtype="MI">
+        <identifier uniqueid="187-2497" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>G3_DOK2</bpref>
+        <bpref>SBAC_PT-4-CR</bpref>
+        <bpref>SBAC_PT-4-CR|2-3</bpref>
+        <bpref>SBAC_PT-4-CR|2-3|3.W.8</bpref>
+        <poolproperty property="--ITEMTYPE--" value="MI" label="MI" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="7.711800000000000e-001" />
+          <itemscoreparameter measurementparameter="b" value="-1.408940000000000e+000" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2498.xml" itemtype="MI">
+        <identifier uniqueid="187-2498" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>SBAC_PT-3-L</bpref>
+        <bpref>SBAC_PT-3-L|4-3</bpref>
+        <bpref>SBAC_PT-3-L|4-3|3.SL.2</bpref>
+        <passageref>187-3732</passageref>
+        <poolproperty property="--ITEMTYPE--" value="MI" label="MI" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="4.172400000000000e-001" />
+          <itemscoreparameter measurementparameter="b" value="-1.354820000000000e+000" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2500.xml" itemtype="MC">
+        <identifier uniqueid="187-2500" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>SBAC_PT-1-LT</bpref>
+        <bpref>SBAC_PT-1-LT|7-3</bpref>
+        <bpref>SBAC_PT-1-LT|7-3|3.L.5a</bpref>
+        <passageref>187-3739</passageref>
+        <poolproperty property="--ITEMTYPE--" value="MC" label="MC" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="1.000000000000000e+000" />
+          <itemscoreparameter measurementparameter="b" value="1.000000000000000e-015" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2510.xml" itemtype="MC">
+        <identifier uniqueid="187-2510" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>SBAC_PT-2-W</bpref>
+        <bpref>SBAC_PT-2-W|9-3</bpref>
+        <poolproperty property="--ITEMTYPE--" value="MC" label="MC" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="5.064800000000000e-001" />
+          <itemscoreparameter measurementparameter="b" value="1.398600000000000e+000" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2521.xml" itemtype="MC">
+        <identifier uniqueid="187-2521" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>G3_DOK2</bpref>
+        <bpref>SBAC_PT-2-W</bpref>
+        <bpref>SBAC_PT-2-W|3-3</bpref>
+        <bpref>SBAC_PT-2-W|3-3|3.W.2a</bpref>
+        <poolproperty property="--ITEMTYPE--" value="MC" label="MC" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="1.000000000000000e+000" />
+          <itemscoreparameter measurementparameter="b" value="1.000000000000000e-015" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2526.xml" itemtype="MS">
+        <identifier uniqueid="187-2526" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>SBAC_PT-1-LT</bpref>
+        <bpref>SBAC_PT-1-LT|6-3</bpref>
+        <bpref>SBAC_PT-1-LT|6-3|3.RL.5</bpref>
+        <passageref>187-3739</passageref>
+        <poolproperty property="--ITEMTYPE--" value="MS" label="MS" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="6.027400000000001e-001" />
+          <itemscoreparameter measurementparameter="b" value="1.027880000000000e+000" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2564.xml" itemtype="HTQ">
+        <identifier uniqueid="187-2564" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>G3_Claim1_T2/12</bpref>
+        <bpref>G3_DOK2</bpref>
+        <bpref>SBAC_PT-1-LT</bpref>
+        <bpref>SBAC_PT-1-LT|2-3</bpref>
+        <bpref>SBAC_PT-1-LT|2-3|3.RL.2</bpref>
+        <passageref>187-3739</passageref>
+        <poolproperty property="--ITEMTYPE--" value="HTQ" label="HTQ" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="1.000000000000000e+000" />
+          <itemscoreparameter measurementparameter="b" value="1.000000000000000e-015" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2577.xml" itemtype="HTQ">
+        <identifier uniqueid="187-2577" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>G3_DOK2</bpref>
+        <bpref>SBAC_PT-2-W</bpref>
+        <bpref>SBAC_PT-2-W|1-3</bpref>
+        <bpref>SBAC_PT-2-W|1-3|3.W.3a</bpref>
+        <poolproperty property="--ITEMTYPE--" value="HTQ" label="HTQ" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="1.000000000000000e+000" />
+          <itemscoreparameter measurementparameter="b" value="1.000000000000000e-015" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2604.xml" itemtype="MS">
+        <identifier uniqueid="187-2604" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>G3_DOK2</bpref>
+        <bpref>SBAC_PT-2-W</bpref>
+        <bpref>SBAC_PT-2-W|8-3</bpref>
+        <bpref>SBAC_PT-2-W|8-3|3.L.6</bpref>
+        <poolproperty property="--ITEMTYPE--" value="MS" label="MS" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="9.339800000000000e-001" />
+          <itemscoreparameter measurementparameter="b" value="3.513700000000000e-001" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2659.xml" itemtype="MC">
+        <identifier uniqueid="187-2659" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>SBAC_PT-1-IT</bpref>
+        <bpref>SBAC_PT-1-IT|13-3</bpref>
+        <bpref>SBAC_PT-1-IT|13-3|3.RI.5</bpref>
+        <passageref>187-3753</passageref>
+        <poolproperty property="--ITEMTYPE--" value="MC" label="MC" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="1.000000000000000e+000" />
+          <itemscoreparameter measurementparameter="b" value="1.000000000000000e-015" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2660.xml" itemtype="HTQ">
+        <identifier uniqueid="187-2660" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>SBAC_PT-1-IT</bpref>
+        <bpref>SBAC_PT-1-IT|11-KG</bpref>
+        <passageref>187-3753</passageref>
+        <poolproperty property="--ITEMTYPE--" value="HTQ" label="HTQ" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="6.604800000000000e-001" />
+          <itemscoreparameter measurementparameter="b" value="1.059700000000000e+000" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2661.xml" itemtype="MS">
+        <identifier uniqueid="187-2661" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>G3_DOK2</bpref>
+        <bpref>SBAC_PT-1-IT</bpref>
+        <bpref>SBAC_PT-1-IT|8-3</bpref>
+        <bpref>SBAC_PT-1-IT|8-3|3.RI.1</bpref>
+        <passageref>187-3753</passageref>
+        <poolproperty property="--ITEMTYPE--" value="MS" label="MS" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="5.686000000000000e-001" />
+          <itemscoreparameter measurementparameter="b" value="8.208800000000001e-001" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2684.xml" itemtype="EBSR">
+        <identifier uniqueid="187-2684" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>G3_Claim1_T2/12</bpref>
+        <bpref>SBAC_PT-1-IT</bpref>
+        <bpref>SBAC_PT-1-IT|12-3</bpref>
+        <passageref>187-3753</passageref>
+        <poolproperty property="--ITEMTYPE--" value="EBSR" label="EBSR" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="1.000000000000000e+000" />
+          <itemscoreparameter measurementparameter="b" value="1.000000000000000e-015" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+      <testitem filename="item-187-2685.xml" itemtype="HTQ">
+        <identifier uniqueid="187-2685" version="8185" />
+        <bpref>(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016</bpref>
+        <bpref>SBAC_PT-1-IT</bpref>
+        <bpref>SBAC_PT-1-IT|10-3</bpref>
+        <bpref>SBAC_PT-1-IT|10-3|3.RI.4</bpref>
+        <passageref>187-3753</passageref>
+        <poolproperty property="--ITEMTYPE--" value="HTQ" label="HTQ" />
+        <poolproperty property="Language" value="ENU" label="English" />
+        <itemscoredimension measurementmodel="IRT3PLn" scorepoints="1" weight="1.000000000000000e+000">
+          <itemscoreparameter measurementparameter="a" value="1.000000000000000e+000" />
+          <itemscoreparameter measurementparameter="b" value="1.000000000000000e-015" />
+          <itemscoreparameter measurementparameter="c" value="0.000000000000000e+000" />
+        </itemscoredimension>
+      </testitem>
+    </itempool>
+    <adminsegment segmentid="(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016" position="1" itemselection="adaptive2">
+      <segmentblueprint>
+        <segmentbpelement bpelementid="SBAC_PT-1-IT" minopitems="2" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-1-LT" minopitems="2" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-2-W" minopitems="1" maxopitems="1" />
+        <segmentbpelement bpelementid="SBAC_PT-3-L" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-4-CR" minopitems="1" maxopitems="1" />
+        <segmentbpelement bpelementid="SBAC_PT-1-IT|10-3" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-1-IT|11-KG" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-1-IT|12-3" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-1-IT|13-3" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-1-IT|8-3" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-1-LT|2-3" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-1-LT|6-3" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-1-LT|7-3" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-2-W|1-3" minopitems="0" maxopitems="1" />
+        <segmentbpelement bpelementid="SBAC_PT-2-W|3-3" minopitems="0" maxopitems="1" />
+        <segmentbpelement bpelementid="SBAC_PT-2-W|8-3" minopitems="0" maxopitems="1" />
+        <segmentbpelement bpelementid="SBAC_PT-2-W|9-3" minopitems="0" maxopitems="1" />
+        <segmentbpelement bpelementid="SBAC_PT-3-L|4-3" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-4-CR|2-3" minopitems="0" maxopitems="1" />
+        <segmentbpelement bpelementid="SBAC_PT-4-CR|3-1" minopitems="0" maxopitems="1" />
+        <segmentbpelement bpelementid="SBAC_PT-1-IT|10-3|3.RI.4" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-1-IT|13-3|3.RI.5" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-1-IT|8-3|3.RI.1" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-1-LT|2-3|3.RL.2" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-1-LT|6-3|3.RL.5" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-1-LT|7-3|3.L.5a" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-2-W|1-3|3.W.3a" minopitems="0" maxopitems="1" />
+        <segmentbpelement bpelementid="SBAC_PT-2-W|3-3|3.W.2a" minopitems="0" maxopitems="1" />
+        <segmentbpelement bpelementid="SBAC_PT-2-W|8-3|3.L.6" minopitems="0" maxopitems="1" />
+        <segmentbpelement bpelementid="SBAC_PT-3-L|4-3|3.SL.2" minopitems="0" maxopitems="2" />
+        <segmentbpelement bpelementid="SBAC_PT-4-CR|2-3|3.W.8" minopitems="0" maxopitems="1" />
+        <segmentbpelement bpelementid="G3_Claim1_T2/12" minopitems="1" maxopitems="1" />
+        <segmentbpelement bpelementid="G3_DOK2" minopitems="2" maxopitems="8" />
+      </segmentblueprint>
+      <itemselector type="adaptive">
+        <identifier uniqueid="AIR ADAPTIVE1" name="AIR ADAPTIVE" label="AIR ADAPTIVE" version="1.0" />
+        <itemselectionparameter bpelementid="(SBAC_PT)SBAC-IRP-CAT-ELA-3-Summer-2015-2016">
+          <property name="bpweight" value="1" label="blueprint metric weight relative to ability metric weight of 1.0" />
+          <property name="startability" value="-1.23998" label="start ability" />
+          <property name="startinfo" value="0.2" label="start information" />
+          <property name="cset1size" value="5" label="cset 1 size" />
+          <property name="cset1order" value="ABILITY" label="cset 1 tie breaker" />
+          <property name="cset2random" value="3" label="randomizer for item selection" />
+          <property name="cset2initialrandom" value="18" label="randomizer for first item selection" />
+          <property name="abilityoffset" value="0" label="offset for ability estimate" />
+          <property name="itemweight" value="1" label="blueprint weight of items in chosen group relative to ability match for final pruning step" />
+          <property name="slope" value="85.8" label="slope" />
+          <property name="intercept" value="2508.2" label="intercept" />
+          <property name="precisiontarget" value="1" label="precision target" />
+          <property name="adaptivecut" value="0" label="adaptive cut" />
+          <property name="toocloseses" value="0" label="too Close SEs" />
+          <property name="abilityweight" value="1" label="ability weight" />
+          <property name="computeabilityestimates" value="false" label="compute ability estimates" />
+          <property name="rcabilityweight" value="0" label="rc ability weight" />
+          <property name="precisionTargetMetWeight" value="1" label="precisionTargetMetWeight" />
+          <property name="precisionTargetNotMetWeight" value="1" label="precisionTargetNotMetWeight" />
+          <property name="terminationOverallInfo" value="false" label="terminationOverallInfo" />
+          <property name="terminationRCInfo" value="false" label="terminationRCInfo" />
+          <property name="terminationMinCount" value="true" label="terminationMinCount" />
+          <property name="terminationTooClose" value="false" label="terminationTooClose" />
+          <property name="terminationFlagsAnd" value="false" label="terminationFlagsAnd" />
+          <property name="offGradeProbAffectProficiency" value="0.01" label="Probability that introducing off-grade items will influence the student proficiency must be less than this value" />
+          <property name="proficientPLevel" value="3" label="Level at which student is considered proficient for the test" />
+          <property name="offGradeMinItemsAdministered" value="30" label="Minimum number of on-grade operational items administered before considering for off-grade items" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-1-IT">
+          <property name="isstrictmax" value="true" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+          <property name="adaptivecut" value="-29.2331" label="adaptive cut point" />
+          <property name="startability" value="-29.2331" label="start ability" />
+          <property name="startinfo" value="0" label="start information" />
+          <property name="scalar" value="5" label="relative ability strand weight" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-1-LT">
+          <property name="isstrictmax" value="true" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+          <property name="adaptivecut" value="-29.2331" label="adaptive cut point" />
+          <property name="startability" value="-29.2331" label="start ability" />
+          <property name="startinfo" value="0" label="start information" />
+          <property name="scalar" value="5" label="relative ability strand weight" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-2-W">
+          <property name="isstrictmax" value="true" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+          <property name="adaptivecut" value="-29.2331" label="adaptive cut point" />
+          <property name="startability" value="-29.2331" label="start ability" />
+          <property name="startinfo" value="0" label="start information" />
+          <property name="scalar" value="5" label="relative ability strand weight" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-3-L">
+          <property name="isstrictmax" value="true" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+          <property name="adaptivecut" value="-29.2331" label="adaptive cut point" />
+          <property name="startability" value="-29.2331" label="start ability" />
+          <property name="startinfo" value="0" label="start information" />
+          <property name="scalar" value="5" label="relative ability strand weight" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-4-CR">
+          <property name="isstrictmax" value="true" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+          <property name="adaptivecut" value="-29.2331" label="adaptive cut point" />
+          <property name="startability" value="-29.2331" label="start ability" />
+          <property name="startinfo" value="0" label="start information" />
+          <property name="scalar" value="5" label="relative ability strand weight" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-1-IT|10-3">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-1-IT|11-KG">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-1-IT|12-3">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-1-IT|13-3">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-1-IT|8-3">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-1-LT|2-3">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-1-LT|6-3">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-1-LT|7-3">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-2-W|1-3">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-2-W|3-3">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-2-W|8-3">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-2-W|9-3">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-3-L|4-3">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-4-CR|2-3">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-4-CR|3-1">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-1-IT|10-3|3.RI.4">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-1-IT|13-3|3.RI.5">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-1-IT|8-3|3.RI.1">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-1-LT|2-3|3.RL.2">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-1-LT|6-3|3.RL.5">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-1-LT|7-3|3.L.5a">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-2-W|1-3|3.W.3a">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-2-W|3-3|3.W.2a">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-2-W|8-3|3.L.6">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-3-L|4-3|3.SL.2">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="SBAC_PT-4-CR|2-3|3.W.8">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="G3_Claim1_T2/12">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+          <property name="startinfo" value="0" label="start information" />
+          <property name="precisiontarget" value="1" label="precision target" />
+          <property name="precisiontargetmetweight" value="0" label="precision target met weight" />
+          <property name="precisiontargetnotmetweight" value="0" label="precision target not met weight" />
+        </itemselectionparameter>
+        <itemselectionparameter bpelementid="G3_DOK2">
+          <property name="isstrictmax" value="false" label="Strict maximum flag" />
+          <property name="bpweight" value="1" label="Blueprint weight relative to other elements" />
+          <property name="startinfo" value="0" label="start information" />
+          <property name="precisiontarget" value="1" label="precision target" />
+          <property name="precisiontargetmetweight" value="0" label="precision target met weight" />
+          <property name="precisiontargetnotmetweight" value="0" label="precision target not met weight" />
+        </itemselectionparameter>
+      </itemselector>
+      <segmentpool>
+        <itemgroup maxitems="ALL" maxresponses="ALL">
+          <identifier uniqueid="G-187-3732-0" name="G-187-3732-0" version="8185" />
+          <passageref>187-3732</passageref>
+          <groupitem itemid="187-2498" groupposition="1" adminrequired="false" responserequired="false" isfieldtest="false" isactive="true" blockid="A" />
+          <groupitem itemid="187-2467" groupposition="2" adminrequired="false" responserequired="false" isfieldtest="false" isactive="true" blockid="A" />
+          <groupitem itemid="187-2458" groupposition="3" adminrequired="false" responserequired="false" isfieldtest="false" isactive="true" blockid="A" />
+        </itemgroup>
+        <itemgroup maxitems="ALL" maxresponses="ALL">
+          <identifier uniqueid="G-187-3739-0" name="G-187-3739-0" version="8185" />
+          <passageref>187-3739</passageref>
+          <groupitem itemid="187-2493" groupposition="1" adminrequired="false" responserequired="false" isfieldtest="false" isactive="true" blockid="A" />
+          <groupitem itemid="187-2564" groupposition="2" adminrequired="false" responserequired="false" isfieldtest="false" isactive="true" blockid="A" />
+          <groupitem itemid="187-2526" groupposition="3" adminrequired="false" responserequired="false" isfieldtest="false" isactive="true" blockid="A" />
+          <groupitem itemid="187-2500" groupposition="4" adminrequired="false" responserequired="false" isfieldtest="false" isactive="true" blockid="A" />
+        </itemgroup>
+        <itemgroup maxitems="ALL" maxresponses="ALL">
+          <identifier uniqueid="G-187-3753-0" name="G-187-3753-0" version="8185" />
+          <passageref>187-3753</passageref>
+          <groupitem itemid="187-2661" groupposition="1" adminrequired="false" responserequired="false" isfieldtest="false" isactive="true" blockid="A" />
+          <groupitem itemid="187-2685" groupposition="2" adminrequired="false" responserequired="false" isfieldtest="false" isactive="true" blockid="A" />
+          <groupitem itemid="187-2660" groupposition="3" adminrequired="false" responserequired="false" isfieldtest="false" isactive="true" blockid="A" />
+          <groupitem itemid="187-2684" groupposition="4" adminrequired="false" responserequired="false" isfieldtest="false" isactive="true" blockid="A" />
+          <groupitem itemid="187-2659" groupposition="5" adminrequired="false" responserequired="false" isfieldtest="false" isactive="true" blockid="A" />
+        </itemgroup>
+        <itemgroup maxitems="ALL" maxresponses="ALL">
+          <identifier uniqueid="I-187-2463" name="I-187-2463" version="8185" />
+          <groupitem itemid="187-2463" groupposition="1" adminrequired="true" responserequired="true" isfieldtest="false" isactive="true" blockid="A" />
+        </itemgroup>
+        <itemgroup maxitems="ALL" maxresponses="ALL">
+          <identifier uniqueid="I-187-2497" name="I-187-2497" version="8185" />
+          <groupitem itemid="187-2497" groupposition="1" adminrequired="true" responserequired="true" isfieldtest="false" isactive="true" blockid="A" />
+        </itemgroup>
+        <itemgroup maxitems="ALL" maxresponses="ALL">
+          <identifier uniqueid="I-187-2510" name="I-187-2510" version="8185" />
+          <groupitem itemid="187-2510" groupposition="1" adminrequired="true" responserequired="true" isfieldtest="false" isactive="true" blockid="A" />
+        </itemgroup>
+        <itemgroup maxitems="ALL" maxresponses="ALL">
+          <identifier uniqueid="I-187-2521" name="I-187-2521" version="8185" />
+          <groupitem itemid="187-2521" groupposition="1" adminrequired="true" responserequired="true" isfieldtest="false" isactive="true" blockid="A" />
+        </itemgroup>
+        <itemgroup maxitems="ALL" maxresponses="ALL">
+          <identifier uniqueid="I-187-2577" name="I-187-2577" version="8185" />
+          <groupitem itemid="187-2577" groupposition="1" adminrequired="true" responserequired="true" isfieldtest="false" isactive="true" blockid="A" />
+        </itemgroup>
+        <itemgroup maxitems="ALL" maxresponses="ALL">
+          <identifier uniqueid="I-187-2604" name="I-187-2604" version="8185" />
+          <groupitem itemid="187-2604" groupposition="1" adminrequired="true" responserequired="true" isfieldtest="false" isactive="true" blockid="A" />
+        </itemgroup>
+      </segmentpool>
+    </adminsegment>
+  </administration>
+</testspecification>

--- a/service/src/test/resources/(SBAC_PT)SBAC-Perf-ELA-5-Fall-2017-2018.xml
+++ b/service/src/test/resources/(SBAC_PT)SBAC-Perf-ELA-5-Fall-2017-2018.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?><testspecification purpose="administration" publisher="SBAC_PT" publishdate="Jul 17 2017  4:15PM" version="1.0">
+  <identifier uniqueid="(SBAC_PT)SBAC-Perf-ELA-5-Fall-2017-2018" name="SBAC-Perf-ELA-5" label="G5 ELA Performance Task" version="12516"/>
+  <property name="subject" value="ELA" label="ELA"/>
+  <property name="grade" value="5" label="grade 5"/>
+  <property name="type" value="summative" label="summative" />
+  <administration>
+    <testblueprint>
+      <bpelement elementtype="segment" minopitems="3" maxopitems="3" minftitems="0" maxftitems="0" opitemcount="0" ftitemcount="3">
+        <identifier uniqueid="(SBAC_PT)SBAC-Perf-S1-ELA-5-Fall-2017-2018" name="SBAC-Perf-S1-ELA-5" version="12516"/>
+      </bpelement>
+      <bpelement elementtype="segment" minopitems="1" maxopitems="1" minftitems="0" maxftitems="0" opitemcount="0" ftitemcount="1">
+        <identifier uniqueid="(SBAC_PT)SBAC-Perf-S2-ELA-5-Fall-2017-2018" name="SBAC-Perf-S2-ELA-5" version="12516"/>
+      </bpelement>
+      <bpelement elementtype="test" minopitems="4" maxopitems="4" minftitems="0" maxftitems="0" opitemcount="0" ftitemcount="4">
+        <identifier uniqueid="(SBAC_PT)SBAC-Perf-ELA-5-Fall-2017-2018" name="SBAC-Perf-ELA-5" version="12516"/>
+      </bpelement>
+      <bpelement elementtype="strand" minopitems="4" maxopitems="4" opitemcount="0" ftitemcount="4">
+        <identifier uniqueid="SBAC_PT-ELA-Undesignated" name="ELA-Undesignated" version="12516"/>
+      </bpelement>
+    </testblueprint>
+    <poolproperty property="--ITEMTYPE--" value="ER" label="ItemType = ER" itemcount="2"/>
+    <poolproperty property="--ITEMTYPE--" value="MI" label="ItemType = MI" itemcount="1"/>
+    <poolproperty property="--ITEMTYPE--" value="WER" label="ItemType = WER" itemcount="1"/>
+    <poolproperty property="Language" value="ENU" label="English" itemcount="4"/>
+    <poolproperty property="Language" value="ENU-Braille" label="Braille" itemcount="4"/>
+    <itempool>
+      <passage filename="stim-187-3751.xml">
+        <identifier uniqueid="187-3751" version="12516"/>
+      </passage>
+      <testitem filename="item-187-2646.xml" itemtype="MI">
+        <identifier uniqueid="187-2646" version="12516"/>
+        <bpref>(SBAC_PT)SBAC-Perf-S1-ELA-5-Fall-2017-2018</bpref>
+        <bpref>SBAC_PT-ELA-Undesignated</bpref>
+        <passageref>187-3751</passageref>
+        <poolproperty property="--ITEMTYPE--" value="MI" label="ItemType = MI"/>
+        <poolproperty property="Language" value="ENU" label="English"/>
+        <poolproperty property="Language" value="ENU-Braille" label="Braille"/>
+        <poolproperty property="Answer Key" value="MI" label="Answer Key"/>
+        <itemscoredimension measurementmodel="RAWSCORE" scorepoints="1" weight="1.000000000000000e+000"/>
+      </testitem>
+      <testitem filename="item-187-2647.xml" itemtype="ER">
+        <identifier uniqueid="187-2647" version="12516"/>
+        <bpref>(SBAC_PT)SBAC-Perf-S1-ELA-5-Fall-2017-2018</bpref>
+        <bpref>SBAC_PT-ELA-Undesignated</bpref>
+        <passageref>187-3751</passageref>
+        <poolproperty property="--ITEMTYPE--" value="ER" label="ItemType = ER"/>
+        <poolproperty property="Language" value="ENU" label="English"/>
+        <poolproperty property="Language" value="ENU-Braille" label="Braille"/>
+        <poolproperty property="Answer Key" value="ER" label="Answer Key"/>
+        <itemscoredimension measurementmodel="RAWSCORE" scorepoints="2" weight="1.000000000000000e+000"/>
+      </testitem>
+      <testitem filename="item-187-2648.xml" itemtype="ER">
+        <identifier uniqueid="187-2648" version="12516"/>
+        <bpref>(SBAC_PT)SBAC-Perf-S1-ELA-5-Fall-2017-2018</bpref>
+        <bpref>SBAC_PT-ELA-Undesignated</bpref>
+        <passageref>187-3751</passageref>
+        <poolproperty property="--ITEMTYPE--" value="ER" label="ItemType = ER"/>
+        <poolproperty property="Language" value="ENU" label="English"/>
+        <poolproperty property="Language" value="ENU-Braille" label="Braille"/>
+        <poolproperty property="Answer Key" value="ER" label="Answer Key"/>
+        <itemscoredimension measurementmodel="RAWSCORE" scorepoints="2" weight="1.000000000000000e+000"/>
+      </testitem>
+      <testitem filename="item-187-2649.xml" itemtype="WER">
+        <identifier uniqueid="187-2649" version="12516"/>
+        <bpref>(SBAC_PT)SBAC-Perf-S2-ELA-5-Fall-2017-2018</bpref>
+        <bpref>SBAC_PT-ELA-Undesignated</bpref>
+        <passageref>187-3751</passageref>
+        <poolproperty property="--ITEMTYPE--" value="WER" label="ItemType = WER"/>
+        <poolproperty property="Language" value="ENU" label="English"/>
+        <poolproperty property="Language" value="ENU-Braille" label="Braille"/>
+        <poolproperty property="Answer Key" value="WER" label="Answer Key"/>
+        <itemscoredimension measurementmodel="RAWSCORE" scorepoints="10" weight="1.000000000000000e+000"/>
+      </testitem>
+    </itempool>
+    <testform length="4">
+      <identifier uniqueid="(SBAC_PT)SBAC-Perf-ELA-5-Fall-2017-2018:Default-ENU" name="(SBAC_PT)SBAC-Perf-ELA-5-Fall-2017-2018:Default-ENU" version="12516"/>
+      <property name="language" value="ENU" label="English"/>
+      <poolproperty property="--ITEMTYPE--" value="ER" label="ItemType = ER" itemcount="2"/>
+      <poolproperty property="--ITEMTYPE--" value="MI" label="ItemType = MI" itemcount="1"/>
+      <poolproperty property="--ITEMTYPE--" value="WER" label="ItemType = WER" itemcount="1"/>
+      <poolproperty property="Language" value="ENU" label="English" itemcount="4"/>
+      <poolproperty property="Language" value="ENU-Braille" label="Braille" itemcount="4"/>
+      <formpartition>
+        <identifier uniqueid="187-1017" name="PracTest::ELAG5::Perf::S1::FA17::ENU" version="12516"/>
+        <itemgroup formposition="1" maxitems="ALL" maxresponses="ALL">
+          <identifier uniqueid="187-1017:G-187-3751-1" name="187-1017:G-187-3751-1" version="12516"/>
+          <passageref>187-3751</passageref>
+          <groupitem itemid="187-2646" formposition="1" groupposition="1" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
+          <groupitem itemid="187-2647" formposition="2" groupposition="2" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
+          <groupitem itemid="187-2648" formposition="3" groupposition="3" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
+        </itemgroup>
+      </formpartition>
+      <formpartition>
+        <identifier uniqueid="187-1019" name="PracTest::ELAG5::Perf::S2::FA17::ENU" version="12516"/>
+        <itemgroup formposition="1" maxitems="ALL" maxresponses="ALL">
+          <identifier uniqueid="187-1019:G-187-3751-2" name="187-1019:G-187-3751-2" version="12516"/>
+          <passageref>187-3751</passageref>
+          <groupitem itemid="187-2649" formposition="1" groupposition="1" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
+        </itemgroup>
+      </formpartition>
+    </testform>
+    <testform length="4">
+      <identifier uniqueid="(SBAC_PT)SBAC-Perf-ELA-5-Fall-2017-2018:Default-ENU-Braille" name="(SBAC_PT)SBAC-Perf-ELA-5-Fall-2017-2018:Default-ENU-Braille" version="12516"/>
+      <property name="language" value="ENU-Braille" label="English"/>
+      <poolproperty property="--ITEMTYPE--" value="ER" label="ItemType = ER" itemcount="2"/>
+      <poolproperty property="--ITEMTYPE--" value="MI" label="ItemType = MI" itemcount="1"/>
+      <poolproperty property="--ITEMTYPE--" value="WER" label="ItemType = WER" itemcount="1"/>
+      <poolproperty property="Language" value="ENU" label="English" itemcount="4"/>
+      <poolproperty property="Language" value="ENU-Braille" label="Braille" itemcount="4"/>
+      <formpartition>
+        <identifier uniqueid="187-1018" name="PracTest::ELAG5::Perf::S1::FA17::BRL" version="12516"/>
+        <itemgroup formposition="1" maxitems="ALL" maxresponses="ALL">
+          <identifier uniqueid="187-1018:G-187-3751-1" name="187-1018:G-187-3751-1" version="12516"/>
+          <passageref>187-3751</passageref>
+          <groupitem itemid="187-2646" formposition="1" groupposition="1" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
+          <groupitem itemid="187-2647" formposition="2" groupposition="2" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
+          <groupitem itemid="187-2648" formposition="3" groupposition="3" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
+        </itemgroup>
+      </formpartition>
+      <formpartition>
+        <identifier uniqueid="187-1020" name="PracTest::ELAG5::Perf::S2::FA17::BRL" version="12516"/>
+        <itemgroup formposition="1" maxitems="ALL" maxresponses="ALL">
+          <identifier uniqueid="187-1020:G-187-3751-2" name="187-1020:G-187-3751-2" version="12516"/>
+          <passageref>187-3751</passageref>
+          <groupitem itemid="187-2649" formposition="1" groupposition="1" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
+        </itemgroup>
+      </formpartition>
+    </testform>
+    <adminsegment segmentid="(SBAC_PT)SBAC-Perf-S1-ELA-5-Fall-2017-2018" position="1" itemselection="fixedform">
+      <segmentblueprint>
+        <segmentbpelement bpelementid="SBAC_PT-ELA-Undesignated" minopitems="3" maxopitems="3"/>
+      </segmentblueprint>
+      <itemselector type="fixedform">
+        <identifier uniqueid="AIR FIXEDFORM1" name="AIR FIXEDFORM" label="AIR FIXEDFORM" version="1.0"/>
+        <itemselectionparameter bpelementid="(SBAC_PT)SBAC-Perf-S1-ELA-5-Fall-2017-2018">
+          <property name="slope" value="1" label="slope"/>
+          <property name="intercept" value="1" label="intercept"/>
+        </itemselectionparameter>
+      </itemselector>
+      <segmentform formpartitionid="187-1017"/>
+      <segmentform formpartitionid="187-1018"/>
+    </adminsegment>
+    <adminsegment segmentid="(SBAC_PT)SBAC-Perf-S2-ELA-5-Fall-2017-2018" position="2" itemselection="fixedform">
+      <segmentblueprint>
+        <segmentbpelement bpelementid="SBAC_PT-ELA-Undesignated" minopitems="1" maxopitems="1"/>
+      </segmentblueprint>
+      <itemselector type="fixedform">
+        <identifier uniqueid="AIR FIXEDFORM1" name="AIR FIXEDFORM" label="AIR FIXEDFORM" version="1.0"/>
+        <itemselectionparameter bpelementid="(SBAC_PT)SBAC-Perf-S2-ELA-5-Fall-2017-2018">
+          <property name="slope" value="1" label="slope"/>
+          <property name="intercept" value="1" label="intercept"/>
+        </itemselectionparameter>
+      </itemselector>
+      <segmentform formpartitionid="187-1019"/>
+      <segmentform formpartitionid="187-1020"/>
+    </adminsegment>
+  </administration>
+</testspecification>

--- a/service/src/test/resources/(SBAC_PT)SBAC-Perf-ELA-8-Fall-2017-2018.xml
+++ b/service/src/test/resources/(SBAC_PT)SBAC-Perf-ELA-8-Fall-2017-2018.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?><testspecification purpose="administration" publisher="SBAC_PT" publishdate="Jul 17 2017  4:15PM" version="1.0">
-  <identifier uniqueid="(SBAC_PT)SBAC-Perf-ELA-5-Fall-2017-2018" name="SBAC-Perf-ELA-5" label="G5 ELA Performance Task" version="12516"/>
+  <identifier uniqueid="(SBAC_PT)SBAC-Perf-ELA-8-Fall-2017-2018" name="SBAC-Perf-ELA-8" label="G8 ELA Performance Task" version="12516"/>
   <property name="subject" value="ELA" label="ELA"/>
-  <property name="grade" value="5" label="grade 5"/>
+  <property name="grade" value="8" label="grade 8"/>
   <property name="type" value="summative" label="summative" />
   <administration>
     <testblueprint>
       <bpelement elementtype="segment" minopitems="3" maxopitems="3" minftitems="0" maxftitems="0" opitemcount="0" ftitemcount="3">
-        <identifier uniqueid="(SBAC_PT)SBAC-Perf-S1-ELA-5-Fall-2017-2018" name="SBAC-Perf-S1-ELA-5" version="12516"/>
+        <identifier uniqueid="(SBAC_PT)SBAC-Perf-S1-ELA-8-Fall-2017-2018" name="SBAC-Perf-S1-ELA-8" version="12516"/>
       </bpelement>
       <bpelement elementtype="segment" minopitems="1" maxopitems="1" minftitems="0" maxftitems="0" opitemcount="0" ftitemcount="1">
-        <identifier uniqueid="(SBAC_PT)SBAC-Perf-S2-ELA-5-Fall-2017-2018" name="SBAC-Perf-S2-ELA-5" version="12516"/>
+        <identifier uniqueid="(SBAC_PT)SBAC-Perf-S2-ELA-8-Fall-2017-2018" name="SBAC-Perf-S2-ELA-8" version="12516"/>
       </bpelement>
       <bpelement elementtype="test" minopitems="4" maxopitems="4" minftitems="0" maxftitems="0" opitemcount="0" ftitemcount="4">
-        <identifier uniqueid="(SBAC_PT)SBAC-Perf-ELA-5-Fall-2017-2018" name="SBAC-Perf-ELA-5" version="12516"/>
+        <identifier uniqueid="(SBAC_PT)SBAC-Perf-ELA-8-Fall-2017-2018" name="SBAC-Perf-ELA-8" version="12516"/>
       </bpelement>
       <bpelement elementtype="strand" minopitems="4" maxopitems="4" opitemcount="0" ftitemcount="4">
         <identifier uniqueid="SBAC_PT-ELA-Undesignated" name="ELA-Undesignated" version="12516"/>
@@ -24,47 +24,47 @@
     <poolproperty property="Language" value="ENU" label="English" itemcount="4"/>
     <poolproperty property="Language" value="ENU-Braille" label="Braille" itemcount="4"/>
     <itempool>
-      <passage filename="stim-187-3751.xml">
-        <identifier uniqueid="187-3751" version="12516"/>
+      <passage filename="stim-187-3758.xml">
+        <identifier uniqueid="187-3758" version="12516"/>
       </passage>
-      <testitem filename="item-187-2646.xml" itemtype="MI">
-        <identifier uniqueid="187-2646" version="12516"/>
-        <bpref>(SBAC_PT)SBAC-Perf-S1-ELA-5-Fall-2017-2018</bpref>
+      <testitem filename="item-187-2695.xml" itemtype="ER">
+        <identifier uniqueid="187-2695" version="12516"/>
+        <bpref>(SBAC_PT)SBAC-Perf-S1-ELA-8-Fall-2017-2018</bpref>
         <bpref>SBAC_PT-ELA-Undesignated</bpref>
-        <passageref>187-3751</passageref>
+        <passageref>187-3758</passageref>
+        <poolproperty property="--ITEMTYPE--" value="ER" label="ItemType = ER"/>
+        <poolproperty property="Language" value="ENU" label="English"/>
+        <poolproperty property="Language" value="ENU-Braille" label="Braille"/>
+        <poolproperty property="Answer Key" value="ER" label="Answer Key"/>
+        <itemscoredimension measurementmodel="RAWSCORE" scorepoints="2" weight="1.000000000000000e+000"/>
+      </testitem>
+      <testitem filename="item-187-2696.xml" itemtype="ER">
+        <identifier uniqueid="187-2696" version="12516"/>
+        <bpref>(SBAC_PT)SBAC-Perf-S1-ELA-8-Fall-2017-2018</bpref>
+        <bpref>SBAC_PT-ELA-Undesignated</bpref>
+        <passageref>187-3758</passageref>
+        <poolproperty property="--ITEMTYPE--" value="ER" label="ItemType = ER"/>
+        <poolproperty property="Language" value="ENU" label="English"/>
+        <poolproperty property="Language" value="ENU-Braille" label="Braille"/>
+        <poolproperty property="Answer Key" value="ER" label="Answer Key"/>
+        <itemscoredimension measurementmodel="RAWSCORE" scorepoints="2" weight="1.000000000000000e+000"/>
+      </testitem>
+      <testitem filename="item-187-2697.xml" itemtype="MI">
+        <identifier uniqueid="187-2697" version="12516"/>
+        <bpref>(SBAC_PT)SBAC-Perf-S1-ELA-8-Fall-2017-2018</bpref>
+        <bpref>SBAC_PT-ELA-Undesignated</bpref>
+        <passageref>187-3758</passageref>
         <poolproperty property="--ITEMTYPE--" value="MI" label="ItemType = MI"/>
         <poolproperty property="Language" value="ENU" label="English"/>
         <poolproperty property="Language" value="ENU-Braille" label="Braille"/>
         <poolproperty property="Answer Key" value="MI" label="Answer Key"/>
         <itemscoredimension measurementmodel="RAWSCORE" scorepoints="1" weight="1.000000000000000e+000"/>
       </testitem>
-      <testitem filename="item-187-2647.xml" itemtype="ER">
-        <identifier uniqueid="187-2647" version="12516"/>
-        <bpref>(SBAC_PT)SBAC-Perf-S1-ELA-5-Fall-2017-2018</bpref>
+      <testitem filename="item-187-2698.xml" itemtype="WER">
+        <identifier uniqueid="187-2698" version="12516"/>
+        <bpref>(SBAC_PT)SBAC-Perf-S2-ELA-8-Fall-2017-2018</bpref>
         <bpref>SBAC_PT-ELA-Undesignated</bpref>
-        <passageref>187-3751</passageref>
-        <poolproperty property="--ITEMTYPE--" value="ER" label="ItemType = ER"/>
-        <poolproperty property="Language" value="ENU" label="English"/>
-        <poolproperty property="Language" value="ENU-Braille" label="Braille"/>
-        <poolproperty property="Answer Key" value="ER" label="Answer Key"/>
-        <itemscoredimension measurementmodel="RAWSCORE" scorepoints="2" weight="1.000000000000000e+000"/>
-      </testitem>
-      <testitem filename="item-187-2648.xml" itemtype="ER">
-        <identifier uniqueid="187-2648" version="12516"/>
-        <bpref>(SBAC_PT)SBAC-Perf-S1-ELA-5-Fall-2017-2018</bpref>
-        <bpref>SBAC_PT-ELA-Undesignated</bpref>
-        <passageref>187-3751</passageref>
-        <poolproperty property="--ITEMTYPE--" value="ER" label="ItemType = ER"/>
-        <poolproperty property="Language" value="ENU" label="English"/>
-        <poolproperty property="Language" value="ENU-Braille" label="Braille"/>
-        <poolproperty property="Answer Key" value="ER" label="Answer Key"/>
-        <itemscoredimension measurementmodel="RAWSCORE" scorepoints="2" weight="1.000000000000000e+000"/>
-      </testitem>
-      <testitem filename="item-187-2649.xml" itemtype="WER">
-        <identifier uniqueid="187-2649" version="12516"/>
-        <bpref>(SBAC_PT)SBAC-Perf-S2-ELA-5-Fall-2017-2018</bpref>
-        <bpref>SBAC_PT-ELA-Undesignated</bpref>
-        <passageref>187-3751</passageref>
+        <passageref>187-3758</passageref>
         <poolproperty property="--ITEMTYPE--" value="WER" label="ItemType = WER"/>
         <poolproperty property="Language" value="ENU" label="English"/>
         <poolproperty property="Language" value="ENU-Braille" label="Braille"/>
@@ -73,7 +73,7 @@
       </testitem>
     </itempool>
     <testform length="4">
-      <identifier uniqueid="(SBAC_PT)SBAC-Perf-ELA-5-Fall-2017-2018:Default-ENU" name="(SBAC_PT)SBAC-Perf-ELA-5-Fall-2017-2018:Default-ENU" version="12516"/>
+      <identifier uniqueid="(SBAC_PT)SBAC-Perf-ELA-8-Fall-2017-2018:Default-ENU" name="(SBAC_PT)SBAC-Perf-ELA-8-Fall-2017-2018:Default-ENU" version="12516"/>
       <property name="language" value="ENU" label="English"/>
       <poolproperty property="--ITEMTYPE--" value="ER" label="ItemType = ER" itemcount="2"/>
       <poolproperty property="--ITEMTYPE--" value="MI" label="ItemType = MI" itemcount="1"/>
@@ -81,26 +81,26 @@
       <poolproperty property="Language" value="ENU" label="English" itemcount="4"/>
       <poolproperty property="Language" value="ENU-Braille" label="Braille" itemcount="4"/>
       <formpartition>
-        <identifier uniqueid="187-1017" name="PracTest::ELAG5::Perf::S1::FA17::ENU" version="12516"/>
+        <identifier uniqueid="187-1029" name="PracTest::ELAG8::Perf::S1::FA17::ENU" version="12516"/>
         <itemgroup formposition="1" maxitems="ALL" maxresponses="ALL">
-          <identifier uniqueid="187-1017:G-187-3751-1" name="187-1017:G-187-3751-1" version="12516"/>
-          <passageref>187-3751</passageref>
-          <groupitem itemid="187-2646" formposition="1" groupposition="1" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
-          <groupitem itemid="187-2647" formposition="2" groupposition="2" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
-          <groupitem itemid="187-2648" formposition="3" groupposition="3" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
+          <identifier uniqueid="187-1029:G-187-3758-1" name="187-1029:G-187-3758-1" version="12516"/>
+          <passageref>187-3758</passageref>
+          <groupitem itemid="187-2695" formposition="1" groupposition="1" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
+          <groupitem itemid="187-2696" formposition="2" groupposition="2" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
+          <groupitem itemid="187-2697" formposition="3" groupposition="3" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
         </itemgroup>
       </formpartition>
       <formpartition>
-        <identifier uniqueid="187-1019" name="PracTest::ELAG5::Perf::S2::FA17::ENU" version="12516"/>
+        <identifier uniqueid="187-1031" name="PracTest::ELAG8::Perf::S2::FA17::ENU" version="12516"/>
         <itemgroup formposition="1" maxitems="ALL" maxresponses="ALL">
-          <identifier uniqueid="187-1019:G-187-3751-2" name="187-1019:G-187-3751-2" version="12516"/>
-          <passageref>187-3751</passageref>
-          <groupitem itemid="187-2649" formposition="1" groupposition="1" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
+          <identifier uniqueid="187-1031:G-187-3758-2" name="187-1031:G-187-3758-2" version="12516"/>
+          <passageref>187-3758</passageref>
+          <groupitem itemid="187-2698" formposition="1" groupposition="1" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
         </itemgroup>
       </formpartition>
     </testform>
     <testform length="4">
-      <identifier uniqueid="(SBAC_PT)SBAC-Perf-ELA-5-Fall-2017-2018:Default-ENU-Braille" name="(SBAC_PT)SBAC-Perf-ELA-5-Fall-2017-2018:Default-ENU-Braille" version="12516"/>
+      <identifier uniqueid="(SBAC_PT)SBAC-Perf-ELA-8-Fall-2017-2018:Default-ENU-Braille" name="(SBAC_PT)SBAC-Perf-ELA-8-Fall-2017-2018:Default-ENU-Braille" version="12516"/>
       <property name="language" value="ENU-Braille" label="English"/>
       <poolproperty property="--ITEMTYPE--" value="ER" label="ItemType = ER" itemcount="2"/>
       <poolproperty property="--ITEMTYPE--" value="MI" label="ItemType = MI" itemcount="1"/>
@@ -108,51 +108,51 @@
       <poolproperty property="Language" value="ENU" label="English" itemcount="4"/>
       <poolproperty property="Language" value="ENU-Braille" label="Braille" itemcount="4"/>
       <formpartition>
-        <identifier uniqueid="187-1018" name="PracTest::ELAG5::Perf::S1::FA17::BRL" version="12516"/>
+        <identifier uniqueid="187-1030" name="PracTest::ELAG8::Perf::S1::FA17::BRL" version="12516"/>
         <itemgroup formposition="1" maxitems="ALL" maxresponses="ALL">
-          <identifier uniqueid="187-1018:G-187-3751-1" name="187-1018:G-187-3751-1" version="12516"/>
-          <passageref>187-3751</passageref>
-          <groupitem itemid="187-2646" formposition="1" groupposition="1" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
-          <groupitem itemid="187-2647" formposition="2" groupposition="2" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
-          <groupitem itemid="187-2648" formposition="3" groupposition="3" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
+          <identifier uniqueid="187-1030:G-187-3758-1" name="187-1030:G-187-3758-1" version="12516"/>
+          <passageref>187-3758</passageref>
+          <groupitem itemid="187-2695" formposition="1" groupposition="1" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
+          <groupitem itemid="187-2696" formposition="2" groupposition="2" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
+          <groupitem itemid="187-2697" formposition="3" groupposition="3" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
         </itemgroup>
       </formpartition>
       <formpartition>
-        <identifier uniqueid="187-1020" name="PracTest::ELAG5::Perf::S2::FA17::BRL" version="12516"/>
+        <identifier uniqueid="187-1032" name="PracTest::ELAG8::Perf::S2::FA17::BRL" version="12516"/>
         <itemgroup formposition="1" maxitems="ALL" maxresponses="ALL">
-          <identifier uniqueid="187-1020:G-187-3751-2" name="187-1020:G-187-3751-2" version="12516"/>
-          <passageref>187-3751</passageref>
-          <groupitem itemid="187-2649" formposition="1" groupposition="1" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
+          <identifier uniqueid="187-1032:G-187-3758-2" name="187-1032:G-187-3758-2" version="12516"/>
+          <passageref>187-3758</passageref>
+          <groupitem itemid="187-2698" formposition="1" groupposition="1" adminrequired="false" responserequired="false" isactive="true" isfieldtest="true" blockid="A"/>
         </itemgroup>
       </formpartition>
     </testform>
-    <adminsegment segmentid="(SBAC_PT)SBAC-Perf-S1-ELA-5-Fall-2017-2018" position="1" itemselection="fixedform">
+    <adminsegment segmentid="(SBAC_PT)SBAC-Perf-S1-ELA-8-Fall-2017-2018" position="1" itemselection="fixedform">
       <segmentblueprint>
         <segmentbpelement bpelementid="SBAC_PT-ELA-Undesignated" minopitems="3" maxopitems="3"/>
       </segmentblueprint>
       <itemselector type="fixedform">
         <identifier uniqueid="AIR FIXEDFORM1" name="AIR FIXEDFORM" label="AIR FIXEDFORM" version="1.0"/>
-        <itemselectionparameter bpelementid="(SBAC_PT)SBAC-Perf-S1-ELA-5-Fall-2017-2018">
+        <itemselectionparameter bpelementid="(SBAC_PT)SBAC-Perf-S1-ELA-8-Fall-2017-2018">
           <property name="slope" value="1" label="slope"/>
           <property name="intercept" value="1" label="intercept"/>
         </itemselectionparameter>
       </itemselector>
-      <segmentform formpartitionid="187-1017"/>
-      <segmentform formpartitionid="187-1018"/>
+      <segmentform formpartitionid="187-1029"/>
+      <segmentform formpartitionid="187-1030"/>
     </adminsegment>
-    <adminsegment segmentid="(SBAC_PT)SBAC-Perf-S2-ELA-5-Fall-2017-2018" position="2" itemselection="fixedform">
+    <adminsegment segmentid="(SBAC_PT)SBAC-Perf-S2-ELA-8-Fall-2017-2018" position="2" itemselection="fixedform">
       <segmentblueprint>
         <segmentbpelement bpelementid="SBAC_PT-ELA-Undesignated" minopitems="1" maxopitems="1"/>
       </segmentblueprint>
       <itemselector type="fixedform">
         <identifier uniqueid="AIR FIXEDFORM1" name="AIR FIXEDFORM" label="AIR FIXEDFORM" version="1.0"/>
-        <itemselectionparameter bpelementid="(SBAC_PT)SBAC-Perf-S2-ELA-5-Fall-2017-2018">
+        <itemselectionparameter bpelementid="(SBAC_PT)SBAC-Perf-S2-ELA-8-Fall-2017-2018">
           <property name="slope" value="1" label="slope"/>
           <property name="intercept" value="1" label="intercept"/>
         </itemselectionparameter>
       </itemselector>
-      <segmentform formpartitionid="187-1019"/>
-      <segmentform formpartitionid="187-1020"/>
+      <segmentform formpartitionid="187-1031"/>
+      <segmentform formpartitionid="187-1032"/>
     </adminsegment>
   </administration>
 </testspecification>


### PR DESCRIPTION
Quick note: 
For the moment, I'm assuming that test/assessment ids are unique and therefore we do not need to verify if other assessments (with different "assessment keys") share the same ID. If we get feedback from SBAC saying that they wish to maintain the possibility of sharing testids between assessments loaded into the system, I will make those updates in a separate PR.

The service method is wrapped in a `@Transactional` in case the delete call fails, in which case all changes would be rolled back by Spring. However, all the of the updates done in the `batchUpdate` call should be called sequentially within the transaction.