### PR TITLE
TDS-1522: changed from 'blueprintweight' to match example XML

### DIFF
--- a/service/src/main/java/tds/assessment/services/impl/AssessmentSegmentLoaderServiceImpl.java
+++ b/service/src/main/java/tds/assessment/services/impl/AssessmentSegmentLoaderServiceImpl.java
@@ -175,7 +175,7 @@ public class AssessmentSegmentLoaderServiceImpl implements AssessmentSegmentLoad
                         .withFieldTestMinItems(segmentBpElement.minFieldTestItems())
                         .withFieldTestMaxItems(segmentBpElement.maxFieldTestItems())
                         .withSelectionAlgorithm(segment.getAlgorithmType().equals("adaptive") ? Algorithm.ADAPTIVE_2.getType() : segment.getAlgorithmType())
-                        .withBlueprintWeight(Float.parseFloat(itemSelectionProperties.getOrDefault("blueprintweight", DEFAULT_BLUEPRINT_WEIGHT)))
+                        .withBlueprintWeight(Float.parseFloat(itemSelectionProperties.getOrDefault("bpweight", DEFAULT_BLUEPRINT_WEIGHT)))
                         .withAbilityWeight(Float.parseFloat(itemSelectionProperties.getOrDefault("abilityweight", DEFAULT_ABILITY_WEIGHT)))
                         .withCSet1Size(Integer.parseInt(itemSelectionProperties.getOrDefault("cset1size", DEFAULT_CSET1_SIZE)))
                         .withCSet2Random(Integer.parseInt(itemSelectionProperties.getOrDefault("cset2random", DEFAULT_CSET2_RANDOM)))


### PR DESCRIPTION
I found this issue while working on TDS-1522 in TIS.  In every example test package XML file we have, the blueprint weight item selection property is named `bpweight` instead of `blueprintweight`.  In `tblSetOfAdminSubjects`, the column is indeed called `blueprintweight` (which is mapped correctly in the Hibernate config/annotations).  However, when attempting to fetch the blueprint weight value, we should (apprently) be looking for `bpweight` in the test package XML.