### PR TITLE
Clearing itembank data even if no assessment object is found

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <mockito.version>1.10.19</mockito.version>
 
         <tds-common.version>5.0.1</tds-common.version>
-        <support-tool-client.version>4.2.0.RELEASE</support-tool-client.version>
+        <support-tool-client.version>4.2.1-SNAPSHOT</support-tool-client.version>
 
         <maven.compiler.plugin.version>3.5.1</maven.compiler.plugin.version>
         <maven.jar.plugin.version>2.3.2</maven.jar.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <mockito.version>1.10.19</mockito.version>
 
         <tds-common.version>5.0.1</tds-common.version>
-        <support-tool-client.version>4.2.1-SNAPSHOT</support-tool-client.version>
+        <support-tool-client.version>4.2.1</support-tool-client.version>
 
         <maven.compiler.plugin.version>3.5.1</maven.compiler.plugin.version>
         <maven.jar.plugin.version>2.3.2</maven.jar.plugin.version>

--- a/service/src/main/java/tds/assessment/repositories/AssessmentCommandRepository.java
+++ b/service/src/main/java/tds/assessment/repositories/AssessmentCommandRepository.java
@@ -26,4 +26,11 @@ public interface AssessmentCommandRepository {
      * @param assessment The {@link tds.assessment.Assessment} object to delete
      */
     void removeAssessmentData(final String clientName, final Assessment assessment);
+
+    /**
+     * Removes {@link tds.assessment.Assessment} data from the TDS database
+     *
+     * @param key The assessment or segment key of the object to delete
+     */
+    void removeItemBankAssessmentData(final String key);
 }

--- a/service/src/main/java/tds/assessment/repositories/AssessmentQueryRepository.java
+++ b/service/src/main/java/tds/assessment/repositories/AssessmentQueryRepository.java
@@ -64,8 +64,17 @@ public interface AssessmentQueryRepository {
 
     /**
      * Finds {@link tds.assessment.model.SegmentMetadata} for the segment key
+     *
      * @param segmentKey the unique segment key
      * @return {@link tds.assessment.model.SegmentMetadata} if found otherwise empty
      */
     Optional<SegmentMetadata> findSegmentMetadata(final String segmentKey);
+
+    /**
+     * Finds keys for any segments present in the assessment (if the assessment is multi-segmented)
+     *
+     * @param assessmentKey The key of the assessment containing the segments
+     * @return The list of segment keys
+     */
+    List<String> findSegmentKeysByAssessmentKey(final String assessmentKey);
 }

--- a/service/src/main/java/tds/assessment/repositories/impl/AssessmentCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/assessment/repositories/impl/AssessmentCommandRepositoryImpl.java
@@ -89,6 +89,12 @@ public class AssessmentCommandRepositoryImpl implements AssessmentCommandReposit
         jdbcTemplate.batchUpdate(SQL.toArray(new String[SQL.size()]));
     }
 
+    @Override
+    public void removeItemBankAssessmentData(final String assessmentKey) {
+        List<String> deleteSql = generateItembankDeleteSQL(assessmentKey);
+        jdbcTemplate.batchUpdate(deleteSql.toArray(new String[deleteSql.size()]));
+    }
+
     private List<String> generateItembankDeleteSQL(final String key) {
         final List<String> SQL = Arrays.stream(ITEMBANK_TABLE_NAMES)
             .map(table -> table.equals("tblsetofadminsubjects")

--- a/service/src/main/java/tds/assessment/repositories/impl/AssessmentQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/assessment/repositories/impl/AssessmentQueryRepositoryImpl.java
@@ -288,6 +288,20 @@ class AssessmentQueryRepositoryImpl implements AssessmentQueryRepository {
         return maybeSegmentMetadata;
     }
 
+    @Override
+    public List<String> findSegmentKeysByAssessmentKey(final String assessmentKey) {
+        final SqlParameterSource parameters = new MapSqlParameterSource("assessmentKey", assessmentKey);
+
+        final String SQL = "SELECT \n" +
+            "  _key\n" +
+            "FROM \n" +
+            "  tblsetofadminsubjects \n" +
+            "WHERE \n" +
+            "  virtualtest = :assessmentKey";
+
+        return jdbcTemplate.queryForList(SQL, parameters, String.class);
+    }
+
     private static class AssessmentInfoRowMapper implements RowMapper<AssessmentInfo> {
         @Override
         public AssessmentInfo mapRow(final ResultSet rs, final int i) throws SQLException {

--- a/service/src/main/java/tds/assessment/services/AssessmentService.java
+++ b/service/src/main/java/tds/assessment/services/AssessmentService.java
@@ -13,6 +13,7 @@
 
 package tds.assessment.services;
 
+import java.util.List;
 import java.util.Optional;
 
 import tds.assessment.Assessment;
@@ -47,5 +48,5 @@ public interface AssessmentService {
      * @param clientName the client environment identifier
      * @param keys        the keys of the {@link tds.assessment.Assessment}
      */
-    void removeAssessment(final String clientName, final String... keys);
+    void removeAssessment(final String clientName, final boolean safeDelete, final String... keys);
 }

--- a/service/src/main/java/tds/assessment/services/impl/AssessmentLoaderServiceImpl.java
+++ b/service/src/main/java/tds/assessment/services/impl/AssessmentLoaderServiceImpl.java
@@ -92,7 +92,7 @@ public class AssessmentLoaderServiceImpl implements AssessmentLoaderService {
             }
         } catch (Exception e) {
             removeTestPackageIfPresent(testPackage);
-            log.error("An error occurred while loading the test package: , Clearing the test package from TDS", e);
+            log.error("An error occurred while loading the test package: {}, Clearing the test package from TDS", testPackage.getId(), e);
             return Optional.of(new ValidationError("TDS-Load", String.format("An error occurred while loading the test package %s. Message: %s",
                 testPackageName, e.getMessage())));
         }
@@ -102,7 +102,7 @@ public class AssessmentLoaderServiceImpl implements AssessmentLoaderService {
     private void removeTestPackageIfPresent(final TestPackage testPackage) {
         try {
             testPackage.getAssessments().forEach(assessment ->
-                assessmentService.removeAssessment(testPackage.getPublisher(), assessment.getKey()));
+                assessmentService.removeAssessment(testPackage.getPublisher(), false, assessment.getKey()));
         } catch (NotFoundException e) {
             // Ignore this exception - no issue if the assessment isn't present in the system
             log.debug("Attempted to clear the assessments in the test package {} before loading, but no assessments were found presently in the system");

--- a/service/src/main/java/tds/assessment/web/endpoints/AssessmentController.java
+++ b/service/src/main/java/tds/assessment/web/endpoints/AssessmentController.java
@@ -67,7 +67,7 @@ class AssessmentController {
     @DeleteMapping(value = "/{clientName}/assessments", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<?> removeAssessment(@PathVariable final String clientName,
                                        @RequestParam("assessmentKey") final String... assessmentKeys) throws NotFoundException {
-        service.removeAssessment(clientName, assessmentKeys);
+        service.removeAssessment(clientName, true, assessmentKeys);
         return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
     }
 }

--- a/service/src/test/java/tds/assessment/repositories/impl/AssessmentCommandRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/assessment/repositories/impl/AssessmentCommandRepositoryImplIntegrationTests.java
@@ -90,6 +90,25 @@ public class AssessmentCommandRepositoryImplIntegrationTests {
     }
 
     @Test
+    public void shouldRemoveCATAssessmentFromItembankSuccessfully() {
+        // Make sure both loaded assessments exist
+        Optional<Assessment> assessment = queryRepository.findAssessmentByKey(TEST_CLIENT_NAME, TEST_ASSESSMENT_KEY);
+        assertThat(assessment.isPresent()).isTrue();
+        Optional<Assessment> assessment2 = queryRepository.findAssessmentByKey(TEST_CLIENT_NAME, TEST_ASSESSMENT_KEY2);
+        assertThat(assessment2.isPresent()).isTrue();
+
+        // Remove only the CAT assessment
+        commandRepository.removeItemBankAssessmentData(TEST_ASSESSMENT_KEY);
+
+        // The second assessment's data should not be affected by the delete
+        Optional<Assessment> retAssessment = queryRepository.findAssessmentByKey(TEST_CLIENT_NAME, TEST_ASSESSMENT_KEY);
+        assertThat(retAssessment.isPresent()).isFalse();
+        Optional<Assessment> retAssessment2 = queryRepository.findAssessmentByKey(TEST_CLIENT_NAME, TEST_ASSESSMENT_KEY2);
+        assertThat(retAssessment2.isPresent()).isTrue();
+        assertThat(assessment2).isEqualTo(retAssessment2);
+    }
+
+    @Test
     public void shouldRemoveFixedFormAssessmentSuccessfully() {
         // Make sure both loaded assessments exist
         Optional<Assessment> assessment = queryRepository.findAssessmentByKey(TEST_CLIENT_NAME, TEST_ASSESSMENT_KEY);

--- a/service/src/test/java/tds/assessment/services/impl/AssessmentLoaderServiceImplTest.java
+++ b/service/src/test/java/tds/assessment/services/impl/AssessmentLoaderServiceImplTest.java
@@ -62,7 +62,7 @@ public class AssessmentLoaderServiceImplTest extends AssessmentLoaderServiceBase
     @Test
     public void shouldReturnWarnForDuplicateIds() {
         final String testPackageName = "V2-(SBAC_PT)IRP-GRADE-11-MATH-EXAMPLE.xml";
-        doThrow(NotFoundException.class).when(assessmentService).removeAssessment(mockTestPackage.getPublisher(), mockTestPackage.getAssessments().get(0).getKey());
+        doThrow(NotFoundException.class).when(assessmentService).removeAssessment(mockTestPackage.getPublisher(), true, mockTestPackage.getAssessments().get(0).getKey());
 
         Set<String> existingIds = ImmutableSet.of("187-1234");
         when(assessmentItemBankLoaderService.findDuplicateItems(mockTestPackage)).thenReturn(existingIds);
@@ -79,7 +79,7 @@ public class AssessmentLoaderServiceImplTest extends AssessmentLoaderServiceBase
     @Test
     public void shouldLoadAssessmentSuccessfullyFirstTime() {
         final String testPackageName = "V2-(SBAC_PT)IRP-GRADE-11-MATH-EXAMPLE.xml";
-        doThrow(NotFoundException.class).when(assessmentService).removeAssessment(mockTestPackage.getPublisher(), mockTestPackage.getAssessments().get(0).getKey());
+        doThrow(NotFoundException.class).when(assessmentService).removeAssessment(mockTestPackage.getPublisher(), true, mockTestPackage.getAssessments().get(0).getKey());
 
         List<TestForm> mockTestForms = randomListOf(2, TestForm.class);
         when(assessmentItemBankLoaderService.loadTestPackage(testPackageName, mockTestPackage, new HashSet<>())).thenReturn(mockTestForms);
@@ -96,7 +96,7 @@ public class AssessmentLoaderServiceImplTest extends AssessmentLoaderServiceBase
 
         List<TestForm> mockTestForms = randomListOf(2, TestForm.class);
         when(assessmentItemBankLoaderService.loadTestPackage(testPackageName, mockTestPackage, new HashSet<>())).thenReturn(mockTestForms);
-        doThrow(NotFoundException.class).when(assessmentService).removeAssessment(mockTestPackage.getPublisher(), mockTestPackage.getAssessments().get(0).getKey());
+        doThrow(NotFoundException.class).when(assessmentService).removeAssessment(mockTestPackage.getPublisher(), true, mockTestPackage.getAssessments().get(0).getKey());
         doThrow(TestPackageLoaderException.class).when(assessmentConfigLoaderService).loadTestPackage(testPackageName, mockTestPackage, mockTestForms);
 
         Optional<ValidationError> maybeError = service.loadTestPackage(testPackageName, mockTestPackage);
@@ -104,7 +104,7 @@ public class AssessmentLoaderServiceImplTest extends AssessmentLoaderServiceBase
 
         verify(assessmentItemBankLoaderService).loadTestPackage(testPackageName, mockTestPackage, new HashSet<>());
         verify(assessmentConfigLoaderService).loadTestPackage(testPackageName, mockTestPackage, mockTestForms);
-        verify(assessmentService, times(2)).removeAssessment(mockTestPackage.getPublisher()
+        verify(assessmentService, times(2)).removeAssessment(mockTestPackage.getPublisher(), true
             , mockTestPackage.getAssessments().get(0).getKey());
     }
 
@@ -119,9 +119,9 @@ public class AssessmentLoaderServiceImplTest extends AssessmentLoaderServiceBase
 
         verify(assessmentItemBankLoaderService).loadTestPackage(testPackageName, mockTestPackage, new HashSet<>());
         verify(assessmentConfigLoaderService).loadTestPackage(testPackageName, mockTestPackage, mockTestForms);
-        verify(assessmentService).removeAssessment(mockTestPackage.getPublisher()
+        verify(assessmentService).removeAssessment(mockTestPackage.getPublisher(), true
             , mockTestPackage.getAssessments().get(0).getKey());
-        verify(assessmentService).removeAssessment(mockTestPackage.getPublisher()
+        verify(assessmentService).removeAssessment(mockTestPackage.getPublisher(), true
             , mockTestPackage.getAssessments().get(1).getKey());
     }
 }

--- a/service/src/test/java/tds/assessment/services/impl/AssessmentServiceImplTest.java
+++ b/service/src/test/java/tds/assessment/services/impl/AssessmentServiceImplTest.java
@@ -175,19 +175,17 @@ public class AssessmentServiceImplTest {
     }
 
     @Test
-    public void shouldRemoveAssessment() {
-        Assessment assessment = random(Assessment.class);
-        when(mockAssessmentQueryRepository.findAssessmentByKey("SBAC_PT", assessment.getKey()))
-            .thenReturn(Optional.of(assessment));
-        service.removeAssessment("SBAC_PT", assessment.getKey());
-        verify(mockAssessmentQueryRepository).findAssessmentByKey("SBAC_PT", assessment.getKey());
-        verify(mockAssessmentCommandRepository).removeAssessmentData("SBAC_PT", assessment);
+    public void shouldRemoveAssessmentUnsafeDelete() {
+        final String key = "assessmentKey";
+        service.removeAssessment("SBAC_PT", false, key);
+        verify(mockAssessmentQueryRepository).findSegmentKeysByAssessmentKey(key);
+        verify(mockAssessmentCommandRepository).removeItemBankAssessmentData(key);
     }
 
     @Test(expected = NotFoundException.class)
     public void shouldThrowForNoAssessmentFoundRemoveAssessment() {
         when(mockAssessmentQueryRepository.findAssessmentByKey("SBAC_PT", "noAssessment"))
             .thenReturn(Optional.empty());
-        service.removeAssessment("SBAC_PT", "noAssessment");
+        service.removeAssessment("SBAC_PT", true, "noAssessment");
     }
 }

--- a/service/src/test/java/tds/assessment/web/endpoints/AssessmentControllerIntegrationTests.java
+++ b/service/src/test/java/tds/assessment/web/endpoints/AssessmentControllerIntegrationTests.java
@@ -163,16 +163,16 @@ public class AssessmentControllerIntegrationTests {
             .param("assessmentKey", "(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016")
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isNoContent());
-        verify(assessmentService).removeAssessment("SBAC_PT", "(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016");
+        verify(assessmentService).removeAssessment("SBAC_PT", true , "(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016");
     }
 
     @Test
     public void shouldReturn404WhenAssessmentNotFound() throws Exception {
-        doThrow(NotFoundException.class).when(assessmentService).removeAssessment("SBAC_PT", "(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016");
+        doThrow(NotFoundException.class).when(assessmentService).removeAssessment("SBAC_PT", true, "(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016");
         http.perform(delete(new URI("/SBAC_PT/assessments"))
             .param("assessmentKey", "(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016")
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound());
-        verify(assessmentService).removeAssessment("SBAC_PT", "(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016");
+        verify(assessmentService).removeAssessment("SBAC_PT", true, "(SBAC_PT)IRP-Perf-ELA-11-Summer-2015-2016");
     }
 }

--- a/service/src/test/java/tds/assessment/web/endpoints/AssessmentControllerTest.java
+++ b/service/src/test/java/tds/assessment/web/endpoints/AssessmentControllerTest.java
@@ -84,6 +84,6 @@ public class AssessmentControllerTest {
         final String clientName = "SBAC_PT";
         final String assessmentKey = "theKey";
         controller.removeAssessment(clientName, assessmentKey);
-        verify(service).removeAssessment(clientName, assessmentKey);
+        verify(service).removeAssessment(clientName, true, assessmentKey);
     }
 }

--- a/service/src/test/resources/application.yml
+++ b/service/src/test/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/itembank
-    username: root
-    password: password123
+    url: ${sbac.jdbc.host}/itembank
+    username: ${sbac.jdbc.user}
+    password: ${sbac.jdbc.password}
     type: com.zaxxer.hikari.HikariDataSource
     driver-class-name: com.mysql.jdbc.Driver
   mvc:

--- a/service/src/test/resources/application.yml
+++ b/service/src/test/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: ${sbac.jdbc.host}/itembank
-    username: ${sbac.jdbc.user}
-    password: ${sbac.jdbc.password}
+    url: jdbc:mysql://localhost:3306/itembank
+    username: root
+    password: password123
     type: com.zaxxer.hikari.HikariDataSource
     driver-class-name: com.mysql.jdbc.Driver
   mvc:


### PR DESCRIPTION
This is a fix for TDS-1745. 

I added a flag to indicate whether the "delete" action should be a safe action or a brute-force delete action. When an exception occurs in the "configs" database load phase (second phase), we need to remove itembank data for a particular assessment key by force. We are unable to wrap both phases of the load in a spring or database transaction because we are using Hibernate to load each entity, and Hibernate does not support inserts to two different schemas within the same transaction. 