### PR TITLE
Ignoring duplicate dependencies that might be defined in a test package

### DIFF
--- a/service/src/main/java/tds/assessment/model/configs/ToolDependency.java
+++ b/service/src/main/java/tds/assessment/model/configs/ToolDependency.java
@@ -17,6 +17,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -203,5 +204,25 @@ public class ToolDependency {
 
     private void setContextType(final String contextType) {
         this.contextType = contextType;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final ToolDependency that = (ToolDependency) o;
+        return Objects.equals(context, that.context) &&
+            Objects.equals(contextType, that.contextType) &&
+            Objects.equals(ifType, that.ifType) &&
+            Objects.equals(ifValue, that.ifValue) &&
+            Objects.equals(thenType, that.thenType) &&
+            Objects.equals(thenValue, that.thenValue) &&
+            Objects.equals(clientName, that.clientName);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(context, contextType, ifType, ifValue, thenType, thenValue, clientName);
     }
 }

--- a/service/src/main/java/tds/assessment/repositories/loader/configs/ToolDependenciesRepository.java
+++ b/service/src/main/java/tds/assessment/repositories/loader/configs/ToolDependenciesRepository.java
@@ -16,10 +16,12 @@ package tds.assessment.repositories.loader.configs;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import tds.assessment.model.configs.ToolDependency;
 
 @Repository
-public interface ToolDependenciesRepository extends CrudRepository<ToolDependency, UUID>{
+public interface ToolDependenciesRepository extends CrudRepository<ToolDependency, UUID> {
+    List<ToolDependency> findByContextAndClientName(final String context, final String clientName);
 }

--- a/service/src/main/java/tds/assessment/services/AssessmentItemSelectionLoaderService.java
+++ b/service/src/main/java/tds/assessment/services/AssessmentItemSelectionLoaderService.java
@@ -25,7 +25,7 @@ public interface AssessmentItemSelectionLoaderService {
     /**
      * Loads scoring measurement seed data into the item bank
      */
-    void loadScoringSeedData();
+    void loadSeedData(final TestPackage testPackage);
 
     /**
      * Loads {@link tds.assessment.model.itembank.ItemMeasurementParameter}s into the item bank

--- a/service/src/main/java/tds/assessment/services/impl/AssessmentConfigSeedDataLoaderServiceImpl.java
+++ b/service/src/main/java/tds/assessment/services/impl/AssessmentConfigSeedDataLoaderServiceImpl.java
@@ -92,10 +92,10 @@ public class AssessmentConfigSeedDataLoaderServiceImpl implements AssessmentConf
         subjectRepository.save(new Subject(clientName, testPackage.getSubject()));
         accommodationFamilyRepository.save(new AccommodationFamily(clientName, testPackage.getSubject()));
 
-        // Load default tool dependency seed data
-        testPackage.getAssessments().forEach(assessment ->
-            jdbcTemplate.update("call configs.InsertToolDependencies(?, ?)", testPackage.getPublisher(), assessment.getId())
-        );
+//        // Load default tool dependency seed data
+//        testPackage.getAssessments().forEach(assessment ->
+//            jdbcTemplate.update("call configs.InsertToolDependencies(?, ?)", testPackage.getPublisher(), assessment.getId())
+//        );
     }
 
     @Override

--- a/service/src/main/java/tds/assessment/services/impl/AssessmentConfigSeedDataLoaderServiceImpl.java
+++ b/service/src/main/java/tds/assessment/services/impl/AssessmentConfigSeedDataLoaderServiceImpl.java
@@ -91,11 +91,6 @@ public class AssessmentConfigSeedDataLoaderServiceImpl implements AssessmentConf
         // Load the client subject and accommodation family
         subjectRepository.save(new Subject(clientName, testPackage.getSubject()));
         accommodationFamilyRepository.save(new AccommodationFamily(clientName, testPackage.getSubject()));
-
-//        // Load default tool dependency seed data
-//        testPackage.getAssessments().forEach(assessment ->
-//            jdbcTemplate.update("call configs.InsertToolDependencies(?, ?)", testPackage.getPublisher(), assessment.getId())
-//        );
     }
 
     @Override

--- a/service/src/main/java/tds/assessment/services/impl/AssessmentItemBankLoaderServiceImpl.java
+++ b/service/src/main/java/tds/assessment/services/impl/AssessmentItemBankLoaderServiceImpl.java
@@ -13,7 +13,6 @@
 
 package tds.assessment.services.impl;
 
-import com.google.common.collect.Lists;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -37,7 +36,6 @@ import tds.assessment.services.AssessmentItemSelectionLoaderService;
 import tds.assessment.services.AssessmentItemStimuliLoaderService;
 import tds.assessment.services.AssessmentSegmentLoaderService;
 import tds.common.Algorithm;
-import tds.support.job.TestPackageLoadJob;
 import tds.testpackage.model.TestPackage;
 
 @Service
@@ -72,7 +70,7 @@ public class AssessmentItemBankLoaderServiceImpl implements AssessmentItemBankLo
 
     @Override
     public List<TestForm> loadTestPackage(final String testPackageName, final TestPackage testPackage, final Set<String> duplicateItemIds) {
-        assessmentItemSelectionLoaderService.loadScoringSeedData();
+        assessmentItemSelectionLoaderService.loadSeedData(testPackage);
 
         //Find client if exists. If not, we need to create one
         final Client client = itemBankDataQueryRepository.findClient(testPackage.getPublisher())

--- a/service/src/main/java/tds/assessment/services/impl/AssessmentLoaderServiceImpl.java
+++ b/service/src/main/java/tds/assessment/services/impl/AssessmentLoaderServiceImpl.java
@@ -20,7 +20,6 @@ import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.stereotype.Service;
 
 import javax.persistence.PersistenceException;
-import javax.persistence.RollbackException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;

--- a/service/src/test/java/tds/assessment/services/impl/AssessmentItemBankLoaderServiceImplTest.java
+++ b/service/src/test/java/tds/assessment/services/impl/AssessmentItemBankLoaderServiceImplTest.java
@@ -26,23 +26,18 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import tds.assessment.exceptions.TestPackageLoaderException;
 import tds.assessment.model.itembank.Client;
 import tds.assessment.model.itembank.TblStrand;
 import tds.assessment.model.itembank.TestForm;
 import tds.assessment.repositories.loader.itembank.ItemBankDataCommandRepository;
 import tds.assessment.repositories.loader.itembank.ItemBankDataQueryRepository;
 import tds.assessment.services.AffinityGroupLoaderService;
-import tds.assessment.services.AssessmentConfigLoaderService;
 import tds.assessment.services.AssessmentFormLoaderService;
 import tds.assessment.services.AssessmentItemBankGenericDataLoaderService;
 import tds.assessment.services.AssessmentItemBankLoaderService;
 import tds.assessment.services.AssessmentItemSelectionLoaderService;
 import tds.assessment.services.AssessmentItemStimuliLoaderService;
-import tds.assessment.services.AssessmentLoaderService;
 import tds.assessment.services.AssessmentSegmentLoaderService;
-import tds.assessment.services.AssessmentService;
-import tds.common.ValidationError;
 
 import static io.github.benas.randombeans.api.EnhancedRandom.random;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -106,7 +101,7 @@ public class AssessmentItemBankLoaderServiceImplTest extends AssessmentLoaderSer
         List<TestForm> testForms = service.loadTestPackage("V2-(SBAC_PT)IRP-GRADE-11-MATH-EXAMPLE.xml", mockTestPackage, new HashSet<>());
         assertThat(testForms).isEmpty();
 
-        verify(assessmentItemSelectionLoaderService).loadScoringSeedData();
+        verify(assessmentItemSelectionLoaderService).loadSeedData(mockTestPackage);
         verify(itemBankDataQueryRepository).findClient("SBAC_PT");
         verify(itemBankDataCommandRepository).insertClient(mockTestPackage.getPublisher());
         verify(assessmentItemBankGenericDataLoaderService).loadSubject(eq(mockTestPackage), isA(Client.class), eq("SBAC_PT-MATH"));
@@ -141,7 +136,7 @@ public class AssessmentItemBankLoaderServiceImplTest extends AssessmentLoaderSer
         List<TestForm> testForms = service.loadTestPackage("V2-(SBAC_PT)IRP-GRADE-11-MATH-EXAMPLE.xml", mockTestPackage, new HashSet<>());
         assertThat(testForms).isEmpty();
 
-        verify(assessmentItemSelectionLoaderService).loadScoringSeedData();
+        verify(assessmentItemSelectionLoaderService).loadSeedData(mockTestPackage);
         verify(itemBankDataQueryRepository).findClient("SBAC_PT");
         verify(itemBankDataCommandRepository, never()).insertClient(mockTestPackage.getPublisher());
         verify(assessmentItemBankGenericDataLoaderService).loadSubject(eq(mockTestPackage), isA(Client.class), eq("SBAC_PT-MATH"));

--- a/service/src/test/java/tds/assessment/services/impl/AssessmentItemSelectionLoaderServiceImplTest.java
+++ b/service/src/test/java/tds/assessment/services/impl/AssessmentItemSelectionLoaderServiceImplTest.java
@@ -21,6 +21,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.util.List;
 import java.util.Map;
@@ -61,6 +62,9 @@ public class AssessmentItemSelectionLoaderServiceImplTest extends AssessmentLoad
     @Mock
     private TblItemSelectionParameterRepository tblItemSelectionParameterRepository;
 
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
     @Captor
     private ArgumentCaptor<List<TblItemSelectionParameter>> selectionParamsArgumentCaptor;
 
@@ -73,14 +77,16 @@ public class AssessmentItemSelectionLoaderServiceImplTest extends AssessmentLoad
     @Before
     public void setup() {
         service = new AssessmentItemSelectionLoaderServiceImpl(itemScoreDimensionsRepository,
-            measurementModelRepository, measurementParameterRepository, itemMeasurementParameterRepository, tblItemSelectionParameterRepository);
+            measurementModelRepository, measurementParameterRepository, itemMeasurementParameterRepository,
+            tblItemSelectionParameterRepository, jdbcTemplate);
     }
 
     @Test
     public void shouldInsertScoringSeedData() {
-        service.loadScoringSeedData();
+        service.loadSeedData(mockTestPackage);
         verify(measurementModelRepository).save(isA(Set.class));
         verify(measurementParameterRepository).save(isA(Set.class));
+        verify(jdbcTemplate).update("call configs.InsertToolDependencies(?, ?)", "SBAC_PT", "SBAC-IRP-CAT-MATH-11");
     }
 
     @Test


### PR DESCRIPTION
Defining dependencies  in the test package that already exists causes weird UI issues in proctor where options are displayed multiple times for each tool. I am now filtering existing tools before I attempt to insert them.